### PR TITLE
docs: widen MkDocs grid for wide-monitor viewports

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -98,3 +98,13 @@
   opacity: 0.5;
   pointer-events: none;
 }
+
+/* === Fluid layout for wide viewports === */
+@media screen and (min-width: 76.25em) {
+  :root {
+    --md-grid-max-width: min(95vw, 130rem);
+  }
+  .md-grid {
+    max-width: min(95vw, 130rem);
+  }
+}


### PR DESCRIPTION
## Summary

- Widen MkDocs Material `.md-grid` max-width to `min(95vw, 130rem)` on viewports >= 76.25em (1220px), so the documentation layout fills wide monitors instead of being capped at the default 61rem (~976px).
- Cap at 130rem (2080px) so content text columns stay readable on ultrawide and 4K monitors.
- Existing mermaid zoom overlay CSS unchanged.

## Effect by Monitor

| Monitor | Before (61rem default) | After (min(95vw, 130rem)) |
|---|---|---|
| 1920x1080 FHD wide | 976px (472px margin/side) | 1824px (48px margin/side) |
| 2560x1440 QHD wide | 976px (792px margin/side) | 2080px (240px margin/side, capped) |
| 3440x1440 ultrawide | 976px (1232px margin/side) | 2080px (680px margin/side, capped) |
| 3840x2160 4K | 976px (1432px margin/side) | 2080px (880px margin/side, capped) |
| <1220px (mobile/tablet/laptop) | unchanged | unchanged |

## Verification

- `mkdocs build --strict` exits 0.
- Mermaid zoom CSS (lines 1-100 of `docs/stylesheets/extra.css`) untouched.
- Only the new `/* === Fluid layout for wide viewports === */` block is added (10 lines).

## Related

Mirrors the change applied to the Azure Container Apps Practical Guide (yeongseon/azure-container-apps-practical-guide#295). Same CSS pattern, same behavior — applied consistently across the practical-guide series.
