### PR TITLE
fix(ci): make Quality Gates green on main

### DIFF
--- a/docs/architecture-reviews/index.md
+++ b/docs/architecture-reviews/index.md
@@ -1,15 +1,18 @@
 ---
 content_sources:
-  - type: self-generated
-    justification: "Navigation index for the Architecture Reviews section, synthesized from Azure Well-Architected Framework review guidance and Azure Architecture Center methodology."
-    based_on:
-      - https://learn.microsoft.com/en-us/azure/well-architected/
-      - https://learn.microsoft.com/en-us/azure/architecture/framework/
-      - https://learn.microsoft.com/en-us/assessments/azure-architecture-review/
+  diagrams:
+    - id: architecture-reviews-methodology
+      type: flowchart
+      source: self-generated
+      justification: "Navigation index for the Architecture Reviews section, synthesized from Azure Well-Architected Framework review guidance and Azure Architecture Center methodology."
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/well-architected/
+        - https://learn.microsoft.com/en-us/azure/architecture/framework/
+        - https://learn.microsoft.com/en-us/assessments/azure-architecture-review/
 ---
 # Architecture Reviews
 
-Architecture Reviews provide a structured methodology for evaluating Azure workloads against the Well-Architected Framework pillars. This section covers decision trees, evidence-based review playbooks, common anti-patterns, and migration strategies.
+[Documented] Architecture Reviews provide a structured methodology for evaluating Azure workloads against the Well-Architected Framework pillars, grounded in Microsoft Learn Well-Architected guidance and Azure Architecture Center methodology. This section covers decision trees, evidence-based review playbooks, common anti-patterns, and migration strategies.
 
 ## Sections
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -127,7 +127,9 @@ Brief introduction
 ```bash
 # ALWAYS use long flags for readability
 az group create --name $RG --location $LOCATION
+```
 
+```text
 # NEVER use short flags in documentation
 az group create -n $RG -l $LOCATION  # ❌ Don't do this
 ```


### PR DESCRIPTION
## Summary

Three Quality Gates jobs have been red on `main` since well before PR #30 shipped, so no PR merged in the past several months got a real pre-merge signal. This PR fixes all three with the minimum edits needed to turn them green.

## Failing jobs (before)

| # | Job | File | Root cause |
|---|---|---|---|
| A | Validate Content Sources | `docs/architecture-reviews/index.md` | Legacy list-form `content_sources`; validator at `scripts/validate_content_sources.py:163` calls `.get("diagrams", ...)` and crashes with `AttributeError: 'list' object has no attribute 'get'` |
| B | Validate Evidence Tags | `docs/architecture-reviews/index.md` | Required file under `docs/architecture-reviews/**/*.md` was missing any of the eight valid evidence tags |
| C | Validate Azure CLI Long Flags | `docs/contributing/index.md:127-133` | Anti-pattern example `az group create -n $RG -l $LOCATION` lived inside the same `bash` fence as the good example, so the validator legitimately flagged it |

## What changed

**`docs/architecture-reviews/index.md`** (fixes A and B):

- Migrated `content_sources` from the legacy list form to the canonical dict form with a `diagrams:` key, matching the pattern used by every other page in the repo (e.g. `docs/index.md`).
- Added `id: architecture-reviews-methodology` to match the existing `<!-- diagram-id: architecture-reviews-methodology -->` comment on the flowchart.
- Added `[Documented]` to the intro paragraph. The claim it tags — that the review methodology is grounded in the Well-Architected Framework and Azure Architecture Center — is directly cited by the two `based_on:` URLs already in the frontmatter. Convention follows the `[Documented] {claim about Microsoft guidance}` pattern used across `docs/patterns/` (10 files) and the rest of the repo.

**`docs/contributing/index.md`** (fix C):

- Split the single ` ```bash ` fence containing both the "good" and "bad" examples into two fences: one ` ```bash ` for the good example, one ` ```text ` for the anti-pattern.
- `scripts/validate_cli_flags.py` scans `TARGET_LANGUAGES = {"bash", "shell", "azurecli"}` only, so the anti-pattern text is now correctly excluded from validation while remaining visible to readers.

## Verification

All eight Quality Gates jobs pass locally:

```
validate_content_sources.py     0 errors  (was 1)
validate_evidence_tags.py       0 missing (was 1)
validate_cli_flags.py           0 issues  (was 2)
validate_mermaid_format.py      0 errors
validate_mermaid_syntax.py      0 errors
validate_pii.py                 0 matches
validate_advr_sections.py       0 missing
mkdocs build --strict           PASS (6.16s)
```

## Scope

Intentionally narrow. Two files, three fixes, one purpose (unblock CI). No other pages touched, no workflow files touched, no refactoring. If the Quality Gates workflow still has structural issues beyond these three jobs, they will be addressed in a follow-up PR.

## Context

This PR is the P1 follow-up flagged by the retrospective Oracle review of PR #30. See the review verdict `APPROVE_WITH_FOLLOW_UP` for the full follow-up plan (this is item #1 of 3).
