### PR TITLE
docs: add series-wide AGENTS sections and architecture profile (P0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,62 @@ Guidance for AI agents working in this repository.
 - **Live site**: <https://yeongseon.github.io/azure-architecture-practical-guide/>
 - **Repository**: <https://github.com/yeongseon/azure-architecture-practical-guide>
 
+## Series-Wide Documentation Contract
+
+This repository is part of the Azure Practical Guide series. All repositories in the series must preserve a consistent reader experience while allowing repository-specific extensions.
+
+### Core Sections
+
+Every service-focused repository SHOULD use these core sections unless the repository-specific addendum explains an exception.
+
+| Section | Required | Purpose |
+|---|---:|---|
+| `Start Here` | Yes | Entry points, overview, learning paths, repository map |
+| `Platform` | Yes | Service concepts, architecture, core behavior |
+| `Best Practices` | Yes | Production patterns, anti-patterns, design guidance |
+| `Operations` | Yes | Day-2 operational procedures and verification |
+| `Troubleshooting` | Yes | Symptom-based diagnosis, playbooks, evidence collection |
+| `Reference` | Yes | CLI, KQL, limits, glossary, decision tables |
+
+### Approved Extension Sections
+
+| Section | Use When |
+|---|---|
+| `Tutorials` | The repository provides hands-on learning or lab sequences |
+| `Lab Guides` | Reproducible experiments or validation exercises are first-class content |
+| `Language Guides` | The service has language/runtime-specific implementation tutorials |
+| `SDK Guides` | The service is primarily consumed through SDKs |
+| `Service Guides` | The repository configures or monitors multiple Azure services |
+| `Workload Guides` | The repository is architecture/workload oriented |
+| `Architecture Reviews` | The repository includes architecture review methodology and playbooks |
+| `Design Labs` | The repository includes architecture design exercises |
+| `Visualization` | Visual maps are a deliberate learning surface, not generated leftovers |
+| `Meta` | Repository taxonomy, content model, or generated metadata |
+
+Do not create a new top-level section if the content can fit under one of the core or approved extension sections.
+
+## Architecture Repository Profile
+
+This repository is not a single Azure service guide. It uses an architecture-specific information architecture.
+
+`Well-Architected Framework`, `Architecture Patterns`, and `Workload Guides` collectively replace the role that `Best Practices` plays in service-specific repositories.
+
+Approved top-level sections:
+
+- `Start Here`
+- `Platform`
+- `Well-Architected Framework`
+- `Architecture Patterns`
+- `Workload Guides`
+- `Operations`
+- `Architecture Reviews`
+- `Design Labs`
+- `Reference`
+
+Do not force this repository into the service-guide core section model where it would reduce clarity.
+
+Large collections should be exposed through workload or review hub pages, not by adding every orphan page directly to the top-level nav.
+
 ## Repository Structure
 
 ```text
@@ -35,6 +91,215 @@ Guidance for AI agents working in this repository.
 ├── scripts/                    # Validation and quality scripts
 └── mkdocs.yml                  # MkDocs Material configuration
 ```
+
+## Start Here Rules
+
+`Start Here` is orientation content. It must not become a language tutorial, SDK tutorial, operations runbook, troubleshooting playbook, or lab guide.
+
+Required pages:
+
+| Page | Purpose |
+|---|---|
+| `overview.md` | Who this guide is for, what is in scope, and what is out of scope |
+| `learning-paths.md` | Role-based and experience-based reading paths |
+| `repository-map.md` | Map of major sections and when to use them |
+
+Optional pages:
+
+| Page Pattern | Purpose |
+|---|---|
+| `when-to-use-*.md` | Service selection guidance |
+| `prerequisites.md` | Required tools, permissions, and accounts |
+| `common-scenarios.md` | Common use cases |
+| `*-vs-other-compute.md` | Positioning against neighboring Azure services |
+| `how-to-use-this-guide.md` | Reader navigation guidance |
+
+`learning-paths.md` MUST:
+
+- Start with role-based or goal-based paths.
+- Link to tutorials instead of embedding a full tutorial sequence.
+- Avoid service-specific code walkthroughs except short examples.
+- Avoid `content_validation` unless this repository explicitly includes Start Here pages in content validation scope.
+
+Preferred title:
+
+```markdown
+# Learning Paths
+```
+
+Avoid:
+
+```markdown
+# Tutorial: {Service} for {Language}
+```
+
+## Navigation Budget
+
+The left navigation should help orientation, not expose every file.
+
+Recommended:
+
+- Top-level sections SHOULD stay between 6 and 9 items.
+- Direct children under a top-level section SHOULD stay between 5 and 8 items.
+- Large collections such as tutorials, recipes, KQL packs, lab guides, and playbooks SHOULD be listed on index pages rather than fully expanded in `mkdocs.yml`.
+- Use hub pages, tables, tags, and search for deep inventory.
+- Keep `mkdocs.yml` readable enough that a contributor can understand the site structure without scrolling through hundreds of deep links.
+
+Preferred troubleshooting structure:
+
+```text
+Troubleshooting
+├─ Overview
+├─ Quick Diagnosis
+├─ Decision Tree
+├─ First 10 Minutes
+├─ Playbooks
+├─ KQL Query Packs
+└─ Labs
+```
+
+Avoid exposing every individual playbook, KQL query, and lab guide in `mkdocs.yml` unless the repository is intentionally small.
+
+## Content Validation Scope
+
+`content_validation` is required for factual-claim pages, not for every Markdown file.
+
+Required by default:
+
+- `docs/platform/**`
+- `docs/best-practices/**`
+- `docs/operations/**`
+- factual troubleshooting methodology/playbook pages
+
+Usually out of scope:
+
+- `docs/start-here/**`
+- `docs/reference/**`
+- `docs/language-guides/**`
+- `docs/sdk-guides/**`
+- `docs/tutorials/**`
+- `docs/troubleshooting/kql/**`
+- `docs/troubleshooting/lab-guides/**`
+- generated dashboards
+- navigation-only index pages
+
+Content-type-specific rules:
+
+- Tutorials use `validation`.
+- Labs use evidence and falsification integrity.
+- KQL packs document query purpose, expected interpretation, required tables, and assumptions.
+- KQL packs do not need `content_validation` unless they make factual platform claims outside the query explanation.
+- Never fabricate validation dates or test results.
+
+## Mermaid Diagrams
+
+Use Mermaid diagrams when they clarify architecture, flow, dependency, decision logic, or troubleshooting paths.
+
+Required for:
+
+- Platform architecture pages
+- Complex operations pages
+- Decision trees
+- Troubleshooting playbooks with multi-step diagnosis
+- Lab guides with failure progression or evidence timelines
+- Architecture review or design decision flows
+
+Optional for:
+
+- Reference tables
+- CLI cheatsheets
+- Glossary pages
+- Generated validation dashboards
+- Short landing pages
+- Simple tutorial steps where prose is clearer
+
+Do not add a diagram just to satisfy a checkbox. A diagram must explain something better than prose or a table.
+
+### Diagram Orientation Rule
+
+- **Sequential flows with 5+ nodes**: Use `flowchart TD` (top-down) to prevent horizontal overflow.
+- **Short diagrams with fewer than 5 nodes**: `flowchart LR` (left-right) is acceptable.
+- **Layered architecture diagrams** (e.g., network layers, stack diagrams): Always use `flowchart TD`.
+
+```mermaid
+%% CORRECT — 5+ node sequential flow uses TD
+flowchart TD
+    A[Commit] --> B[Build and test]
+    B --> C[Package artifact]
+    C --> D[Deploy to staging]
+    D --> E[Validation]
+    E --> F[Swap to production]
+
+%% WRONG — long horizontal overflow
+flowchart LR
+    A[Commit] --> B[Build and test] --> C[Package] --> D[Deploy] --> E[Validate] --> F[Swap]
+```
+
+## Image and Screenshot Rules
+
+Images must support the reader's task. Do not add screenshots only for decoration.
+
+Every referenced image MUST have:
+
+- Descriptive alt text.
+- A nearby explanation of what the reader should verify.
+- No real subscription IDs, tenant IDs, object IDs, emails, phone numbers, secrets, keys, connection strings, or customer data.
+- Visual verification before merge when the image is referenced from Markdown.
+
+Recommended explanation pattern:
+
+```markdown
+![Container App overview showing a healthy revision](../assets/example.png)
+
+Purpose: Confirm why this image exists.
+Look for: Tell the reader what values or states to confirm.
+Expected result: State the healthy or expected condition.
+Next step: Link the image to the next action.
+```
+
+Portal screenshots:
+
+- Prefer text replacement over black-box redaction.
+- Use black-box masking only for unavoidable avatar/profile pixels and only with the repository-approved mask color.
+- If a screenshot cannot be visually verified, remove the Markdown reference or disclose the debt explicitly in the PR.
+
+## Microsoft Learn URL Locale
+
+All `learn.microsoft.com` URLs SHOULD use the `en-us` locale prefix.
+
+Canonical form:
+
+```text
+https://learn.microsoft.com/en-us/azure/{service}/...
+```
+
+Avoid locale-less URLs:
+
+```text
+https://learn.microsoft.com/azure/{service}/...
+```
+
+Reason:
+
+- Stable reader experience.
+- Stable reviewer experience.
+- Easier link checking.
+- Less URL drift across repositories.
+
+## Related Projects
+
+| Repository | Description |
+|---|---|
+| [azure-virtual-machine-practical-guide](https://github.com/yeongseon/azure-virtual-machine-practical-guide) | Azure Virtual Machines practical guide |
+| [azure-networking-practical-guide](https://github.com/yeongseon/azure-networking-practical-guide) | Azure Networking practical guide |
+| [azure-storage-practical-guide](https://github.com/yeongseon/azure-storage-practical-guide) | Azure Storage practical guide |
+| [azure-app-service-practical-guide](https://github.com/yeongseon/azure-app-service-practical-guide) | Azure App Service practical guide |
+| [azure-functions-practical-guide](https://github.com/yeongseon/azure-functions-practical-guide) | Azure Functions practical guide |
+| [azure-communication-services-practical-guide](https://github.com/yeongseon/azure-communication-services-practical-guide) | Azure Communication Services practical guide |
+| [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps practical guide |
+| [azure-kubernetes-service-practical-guide](https://github.com/yeongseon/azure-kubernetes-service-practical-guide) | Azure Kubernetes Service (AKS) practical guide |
+| [azure-architecture-practical-guide](https://github.com/yeongseon/azure-architecture-practical-guide) | Azure Architecture practical guide |
+| [azure-monitoring-practical-guide](https://github.com/yeongseon/azure-monitoring-practical-guide) | Azure Monitoring practical guide |
 
 ## Content Categories
 
@@ -145,30 +410,6 @@ For MkDocs admonitions (`!!!` / `???`), every line in the body must be indented 
     This line is correctly indented.
 
     - List item also inside
-```
-
-### Mermaid Diagrams
-
-All architectural diagrams use Mermaid. Every documentation page should include at least one diagram. Test with `mkdocs build --strict`.
-
-#### Diagram Orientation Rule
-
-- **Sequential flows with 5+ nodes**: Use `flowchart TD` (top-down) to prevent horizontal overflow.
-- **Short diagrams with fewer than 5 nodes**: `flowchart LR` (left-right) is acceptable.
-- **Layered architecture diagrams** (e.g., network layers, stack diagrams): Always use `flowchart TD`.
-
-```mermaid
-%% CORRECT — 5+ node sequential flow uses TD
-flowchart TD
-    A[Commit] --> B[Build and test]
-    B --> C[Package artifact]
-    C --> D[Deploy to staging]
-    D --> E[Validation]
-    E --> F[Swap to production]
-
-%% WRONG — long horizontal overflow
-flowchart LR
-    A[Commit] --> B[Build and test] --> C[Package] --> D[Deploy] --> E[Validate] --> F[Swap]
 ```
 
 ### Nested List Indentation
@@ -436,17 +677,3 @@ type: short description
 ```
 
 Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`
-
-## Related Projects
-
-| Repository | Description |
-|---|---|
-| [azure-virtual-machine-practical-guide](https://github.com/yeongseon/azure-virtual-machine-practical-guide) | Azure Virtual Machines practical guide |
-| [azure-networking-practical-guide](https://github.com/yeongseon/azure-networking-practical-guide) | Azure Networking practical guide |
-| [azure-storage-practical-guide](https://github.com/yeongseon/azure-storage-practical-guide) | Azure Storage practical guide |
-| [azure-app-service-practical-guide](https://github.com/yeongseon/azure-app-service-practical-guide) | Azure App Service practical guide |
-| [azure-functions-practical-guide](https://github.com/yeongseon/azure-functions-practical-guide) | Azure Functions practical guide |
-| [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps practical guide |
-| [azure-communication-services-practical-guide](https://github.com/yeongseon/azure-communication-services-practical-guide) | Azure Communication Services practical guide |
-| [azure-kubernetes-service-practical-guide](https://github.com/yeongseon/azure-kubernetes-service-practical-guide) | Azure Kubernetes Service (AKS) practical guide |
-| [azure-monitoring-practical-guide](https://github.com/yeongseon/azure-monitoring-practical-guide) | Azure Monitoring practical guide |

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Contributions welcome! Please see our [Contributing Guide](https://yeongseon.git
 | [azure-storage-practical-guide](https://github.com/yeongseon/azure-storage-practical-guide) | Azure Storage practical guide |
 | [azure-app-service-practical-guide](https://github.com/yeongseon/azure-app-service-practical-guide) | Azure App Service practical guide |
 | [azure-functions-practical-guide](https://github.com/yeongseon/azure-functions-practical-guide) | Azure Functions practical guide |
-| [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps practical guide |
 | [azure-communication-services-practical-guide](https://github.com/yeongseon/azure-communication-services-practical-guide) | Azure Communication Services practical guide |
+| [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps practical guide |
 | [azure-kubernetes-service-practical-guide](https://github.com/yeongseon/azure-kubernetes-service-practical-guide) | Azure Kubernetes Service (AKS) practical guide |
+| [azure-architecture-practical-guide](https://github.com/yeongseon/azure-architecture-practical-guide) | Azure Architecture practical guide |
 | [azure-monitoring-practical-guide](https://github.com/yeongseon/azure-monitoring-practical-guide) | Azure Monitoring practical guide |
 
 ## Disclaimer


### PR DESCRIPTION
## Summary

Applies P0 items from the series-wide fix guide to the Architecture repo. This is the first of 10 planned PRs (one per repo in the Azure Practical Guide series) covering series-wide AGENTS.md consistency and repository-specific profiles.

## Changes

### AGENTS.md

Added 8 canonical top-level sections in the Oracle-approved insertion order:

- **Series-Wide Documentation Contract** (1.1) — inserted before `## Repository Structure`. Defines core sections (`Start Here`, `Platform`, `Best Practices`, `Operations`, `Troubleshooting`, `Reference`) and approved extension sections shared across the series.
- **Architecture Repository Profile** — inserted before `## Repository Structure`, right after 1.1. Documents that this repo uses `Well-Architected Framework`, `Architecture Patterns`, and `Workload Guides` in place of `Best Practices`, and lists the approved top-level sections for architecture repos.
- **Start Here Rules** (1.2) — inserted before `## Content Categories`. Constrains `Start Here` to orientation content and sets `learning-paths.md` requirements.
- **Navigation Budget** (1.3) — 6-9 top-level, 5-8 second-level. Preferred troubleshooting structure listed.
- **Content Validation Scope** (1.4) — clarifies that `content_validation` is required for factual-claim pages only, not every Markdown file.
- **Mermaid Diagrams** (1.5) — replaces the older "Every documentation page should include at least one diagram" rule. Diagram Orientation Rule preserved as a subsection.
- **Image and Screenshot Rules** (1.6) — describes required alt text, verification statement, and PII rules.
- **Microsoft Learn URL Locale** (1.7) — canonical `en-us` prefix.
- **Related Projects** (1.8) — replaces the pre-existing 9-row table (previously located at the bottom of the file) with the canonical 10-row table that always includes self.

Removed:

- Old bottom `## Related Projects` (9 rows, no self-inclusion) — replaced by canonical 10-row table at the 1.8 position.
- Old `### Mermaid Diagrams` H3 subsection under Documentation Conventions, including the conflicting "Every documentation page should include at least one diagram" rule. The Diagram Orientation Rule is preserved under new 1.5.

### README.md

- Related Projects table updated to canonical 10-row (adds self-inclusion, matches AGENTS.md).

## Insertion order rationale

Per Oracle-approved plan:

1. Series-wide 1.1 + Architecture Repository Profile go **BEFORE `## Repository Structure`** (near the top, after `## Project Overview`).
2. Sections 1.2-1.8 go **AFTER `## Repository Structure`** and **BEFORE `## Content Categories`**.
3. `## Repository Structure` is NOT moved from its existing position.

Final AGENTS.md heading order:

```
## Project Overview
## Series-Wide Documentation Contract
## Architecture Repository Profile
## Repository Structure
## Start Here Rules
## Navigation Budget
## Content Validation Scope
## Mermaid Diagrams
## Image and Screenshot Rules
## Microsoft Learn URL Locale
## Related Projects
## Content Categories
## Content Types & Methodology
## Documentation Conventions
## Content Source Requirements
## Quality Gates & Verification
## Mandatory Oracle Review (AI Agent Rule)
## Tutorial Validation Tracking
## Build & Preview
## Git Commit Style
```

## Test plan

- [x] `mkdocs build --strict` passes (5.94s, no warnings related to this change)
- [x] `grep` sweep confirms no residual "Every documentation page should include at least one diagram" rule
- [x] Only one `## Related Projects` remains in AGENTS.md (at the 1.8 position between Microsoft Learn URL Locale and Content Categories)
- [x] Series-Wide Documentation Contract lists all 6 core sections and 10 approved extensions
- [x] Architecture Repository Profile lists 9 approved top-level sections (Start Here, Platform, WAF, Patterns, Workload Guides, Operations, Architecture Reviews, Design Labs, Reference)
- [x] Related Projects tables in AGENTS.md and README.md match (10 rows, self-included)

## Notes for reviewer

- The Diagram Orientation Rule (TD vs LR) is a repository-specific practical guideline that predates the fix guide. I preserved it as a subsection under new `## Mermaid Diagrams` (1.5) rather than deleting it, since it's orthogonal to the "when to include a diagram" rule that was superseded. Please flag if you'd prefer it moved elsewhere or dropped.
- This is PR 1 of 10 in the series-wide P0 rollout. The insertion pattern (1.1 + repo profile before Repository Structure; 1.2-1.8 before Content Categories) will be applied consistently to all 10 repos.

## Related

- Series-wide fix guide (canonical source): local `/tmp/fix-guide.md`
- Oracle initial + follow-up review approved 2026-07-01 (session `ses_0e35149f0ffeVFPCUX5UDd0sdK`)
