### PR TITLE
docs(contributing): amend nav contract § 4 to allow D2-D3 extension placement

### DIFF
--- a/docs/contributing/series-nav-contract.md
+++ b/docs/contributing/series-nav-contract.md
@@ -74,7 +74,7 @@ Adds these SHOULD elements on top of the MUST tier:
 | D3 | **Operations** | Fifth | Day-2 execution procedures. Series-wide standard section. |
 | D4 | **Troubleshooting** | Sixth (immediately after Operations) | Symptom-based diagnosis and playbooks. Positioned adjacent to Operations because the two sections are cross-linked heavily. |
 
-Approved 문서형 extensions (MAY sit between D3 and D4 or after D4, at the repo owner's discretion):
+Approved 문서형 extensions (MAY sit between D2 and D3, between D3 and D4, or after D4, at the repo owner's discretion):
 
 - `Tutorials` — hands-on labs or reproducible walkthroughs (used by networking, storage).
 - `Well-Architected Framework` — WAF pillar guidance (used by architecture).


### PR DESCRIPTION
## Summary

- **Single-line amendment** to § 4 of the Series Navigation Contract v1 (merged in #44).
- Removes the internal contradiction between § 4 (which forbade D2-D3 extension placement) and § 7 (which listed \`aks\` and \`monitoring\` — both using D2-D3 placement — as "Fully compliant").
- Empirically validated across all 10 sibling repos on 2026-07-09.

## Change

**Before** (line 77):

> Approved 문서형 extensions (MAY sit between D3 and D4 or after D4, at the repo owner's discretion):

**After**:

> Approved 문서형 extensions (MAY sit between D2 and D3, between D3 and D4, or after D4, at the repo owner's discretion):

Where D2 = Best Practices, D3 = Operations, D4 = Troubleshooting.

## Why

Contract § 7 lists these repos as "Fully compliant":

| Repo | Extension | Position | Falls between |
|---|---|---:|---|
| aks | Tutorials | 5 | **D2-D3** (BP-Ops) |
| monitoring | Service Guides | 5 | **D2-D3** (BP-Ops) |
| networking | Tutorials | 6 | D3-D4 (Ops-TS) |
| storage | Tutorials | 6 | D3-D4 (Ops-TS) |

Before this amendment, § 4 literally permitted only D3-D4 and post-D4 placements, meaning aks and monitoring were contradictorily flagged as compliant in § 7 while violating § 4. The amendment adds D2-D3 as a third permitted placement, making § 4 consistent with the empirical reality that § 7 already accepts.

## Scope discipline

Per Oracle guidance during Phase 3.10 review, this PR is intentionally narrow:

- ✅ Fixes only the D2-D3 placement wording in § 4.
- ❌ Does NOT reopen broader nav-policy questions.
- ❌ Does NOT add new approved extensions.
- ❌ Does NOT modify § 5 (코드형 archetype).
- ❌ Does NOT modify § 7 Per-Repo Applicability (it becomes internally consistent automatically once § 4 is amended).

## Verification

- \`mkdocs build --strict\` passes (4.96s locally).
- No other file changes required.

Closes #45