### PR TITLE
docs(reference): add cross-repo service-selection deep-guide bridges (P1a #34)

### DIFF
--- a/docs/reference/architecture-decision-matrix.md
+++ b/docs/reference/architecture-decision-matrix.md
@@ -1,4 +1,5 @@
 ---
+description: Cross-repo service-selection matrix — maps each Azure workload type to its likely service combination and the sibling deep-guide entry point for that service.
 content_sources:
   diagrams:
     - id: architecture-decision-matrix-flow
@@ -8,17 +9,27 @@ content_sources:
 ---
 # Architecture Decision Matrix
 
-This matrix helps architects move from workload type to likely Azure service combinations. Use it as a first-pass filter, then validate with workload guides and design labs.
+This matrix helps architects move from workload type to a likely Azure service combination, then hands off to the sibling deep-guide for the chosen service. Use it as a first-pass filter, validate with the workload guides and design labs, then follow the **Deep guide** link to production-grade platform, best-practices, and troubleshooting depth.
 
-| Workload type | Front-end and compute | Data and state | Integration | Notes |
+For service-area routing when you already know the service, use the [Series Portal](series-portal.md). For deeper single-dimension comparisons, use the [compute](compute-selection-cheatsheet.md), [data](data-selection-cheatsheet.md), [messaging](messaging-selection-cheatsheet.md), and [network](network-topology-cheatsheet.md) cheatsheets.
+
+## How to use this matrix
+
+- Find the row whose **workload type** matches yours; the middle columns give a defensible first-pass service combination.
+- Treat these as starting points, not verdicts — confirm against the linked cheatsheets and your workload's specific constraints. [Inferred]
+- Once a service is chosen, follow its **Deep guide** entry point to the sibling practical guide for that service. Every sibling guide follows the same Start Here → Platform → Best Practices → Operations → Troubleshooting → Reference shape. [Documented]
+
+## Workload-to-service matrix
+
+| Workload type | Front-end and compute | Data and state | Integration | Deep guide |
 |---|---|---|---|---|
-| Public web application | Front Door + App Service | Azure SQL + Key Vault | Event Grid or Service Bus as needed | Strong baseline for managed HTTP workloads. [Documented] |
-| Private internal application | App Service Private Endpoint for inbound + App Service VNet integration for outbound | Azure SQL or PostgreSQL + Key Vault | Private Endpoints, optional Service Bus | Prefer when no internet exposure is allowed. [Documented] |
-| Event-driven business workflow | API + Functions or App Service | Cosmos DB or Azure SQL | Service Bus + Event Grid | Best for decoupled processing and notifications. [Correlated] |
-| Serverless file or data processing | Functions or Container Apps jobs | Storage + optional Redis | Event Grid or queues | Strong elasticity for bursty pipelines. [Observed] |
-| Microservices platform | AKS or Container Apps | Polyglot stores | Service Bus, Event Grid, API gateway | Choose only if service autonomy justifies the added ops load. [Inferred] |
-| Data analytics | Synapse, Databricks, or Fabric-adjacent patterns | Data Lake + analytical stores | Event Hubs or batch ingestion | Optimized for large-scale data movement and analytics. [Documented] |
-| Enterprise landing zone shared services | Shared platform services | Central policy and logs | Hub-spoke or Virtual WAN | Focus on governance and connectivity. [Validated] |
+| Public web application | Front Door + App Service | Azure SQL + Key Vault | Event Grid or Service Bus as needed | [App Service](https://yeongseon.github.io/azure-app-service-practical-guide/start-here/scenario-router/) |
+| Private internal application | App Service Private Endpoint for inbound + App Service VNet integration for outbound | Azure SQL or PostgreSQL + Key Vault | Private Endpoints, optional Service Bus | [App Service](https://yeongseon.github.io/azure-app-service-practical-guide/start-here/scenario-router/) · [Networking](https://yeongseon.github.io/azure-networking-practical-guide/start-here/scenario-router/) |
+| Event-driven business workflow | API + Functions or App Service | Cosmos DB or Azure SQL | Service Bus + Event Grid | [Functions](https://yeongseon.github.io/azure-functions-practical-guide/start-here/) |
+| Serverless file or data processing | Functions or Container Apps jobs | Storage + optional Redis | Event Grid or queues | [Functions](https://yeongseon.github.io/azure-functions-practical-guide/start-here/) · [Container Apps](https://yeongseon.github.io/azure-container-apps-practical-guide/start-here/scenario-router/) |
+| Microservices platform | AKS or Container Apps | Polyglot stores | Service Bus, Event Grid, API gateway | [Container Apps](https://yeongseon.github.io/azure-container-apps-practical-guide/start-here/scenario-router/) · [AKS](https://yeongseon.github.io/azure-kubernetes-service-practical-guide/start-here/scenario-router/) |
+| Data analytics | Synapse, Databricks, or Fabric-adjacent patterns | Data Lake + analytical stores | Event Hubs or batch ingestion | [Storage](https://yeongseon.github.io/azure-storage-practical-guide/start-here/scenario-router/) |
+| Enterprise landing zone shared services | Shared platform services | Central policy and logs | Hub-spoke or Virtual WAN | [Networking](https://yeongseon.github.io/azure-networking-practical-guide/start-here/scenario-router/) · [Monitoring](https://yeongseon.github.io/azure-monitoring-practical-guide/start-here/scenario-router/) |
 
 ## Selection notes
 
@@ -39,7 +50,15 @@ flowchart TD
     E --> F
 ```
 
-## Microsoft Learn references
+## See Also
+
+- [Series Portal](series-portal.md) — route to a sibling deep-guide when the service is already chosen
+- [Compute Selection Cheatsheet](compute-selection-cheatsheet.md) — narrow compute options
+- [Data Selection Cheatsheet](data-selection-cheatsheet.md) — narrow data platform options
+- [Messaging Selection Cheatsheet](messaging-selection-cheatsheet.md) — narrow messaging primitives
+- [Network Topology Cheatsheet](network-topology-cheatsheet.md) — narrow networking topology
+
+## Sources
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree

--- a/docs/reference/compute-selection-cheatsheet.md
+++ b/docs/reference/compute-selection-cheatsheet.md
@@ -1,4 +1,5 @@
 ---
+description: Compare Azure compute services — VMs, App Service, Functions, Container Apps, and AKS — by use case, scaling, cost, skill, and control during early architecture workshops.
 content_sources:
   diagrams:
     - id: compute-selection-map
@@ -40,7 +41,15 @@ flowchart TD
     H -->|No| J[Azure Container Apps]
 ```
 
-## Microsoft Learn references
+## See Also
+
+- [Architecture Decision Matrix](architecture-decision-matrix.md) — workload-to-service selection and sibling deep-guide entry points
+- [Series Portal](series-portal.md) — route to a sibling deep-guide once the service is chosen
+- [Data Selection Cheatsheet](data-selection-cheatsheet.md) — narrow data platform options
+- [Messaging Selection Cheatsheet](messaging-selection-cheatsheet.md) — narrow messaging primitives
+- [Network Topology Cheatsheet](network-topology-cheatsheet.md) — narrow networking topology
+
+## Sources
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/

--- a/docs/reference/data-selection-cheatsheet.md
+++ b/docs/reference/data-selection-cheatsheet.md
@@ -1,4 +1,5 @@
 ---
+description: Compare Azure data stores — SQL, Cosmos DB, PostgreSQL, Storage, and Managed Redis — by data model, consistency, scale, and cost to pick a workload's primary store.
 content_sources:
   diagrams:
     - id: data-selection-map
@@ -42,7 +43,15 @@ flowchart TD
     H -->|Cache| J[Azure Managed Redis]
 ```
 
-## Microsoft Learn references
+## See Also
+
+- [Architecture Decision Matrix](architecture-decision-matrix.md) — workload-to-service selection and sibling deep-guide entry points
+- [Series Portal](series-portal.md) — route to a sibling deep-guide once the service is chosen
+- [Compute Selection Cheatsheet](compute-selection-cheatsheet.md) — narrow compute options
+- [Messaging Selection Cheatsheet](messaging-selection-cheatsheet.md) — narrow messaging primitives
+- [Network Topology Cheatsheet](network-topology-cheatsheet.md) — narrow networking topology
+
+## Sources
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/data-store-overview
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/

--- a/docs/reference/messaging-selection-cheatsheet.md
+++ b/docs/reference/messaging-selection-cheatsheet.md
@@ -1,4 +1,5 @@
 ---
+description: Compare Azure messaging services — Service Bus, Event Grid, Event Hubs, and Queue Storage — by pattern, ordering, throughput, and delivery to match the interaction style.
 content_sources:
   diagrams:
     - id: messaging-selection-map
@@ -36,7 +37,15 @@ flowchart TD
     G -->|Yes| H[Azure Queue Storage]
 ```
 
-## Microsoft Learn references
+## See Also
+
+- [Architecture Decision Matrix](architecture-decision-matrix.md) — workload-to-service selection and sibling deep-guide entry points
+- [Series Portal](series-portal.md) — route to a sibling deep-guide once the service is chosen
+- [Compute Selection Cheatsheet](compute-selection-cheatsheet.md) — narrow compute options
+- [Data Selection Cheatsheet](data-selection-cheatsheet.md) — narrow data platform options
+- [Network Topology Cheatsheet](network-topology-cheatsheet.md) — narrow networking topology
+
+## Sources
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/messaging
 - https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven

--- a/docs/reference/network-topology-cheatsheet.md
+++ b/docs/reference/network-topology-cheatsheet.md
@@ -1,4 +1,5 @@
 ---
+description: Compare Azure network topologies — hub-spoke, Virtual WAN, and flat VNet — plus the Private Endpoint vs Service Endpoint choice for enterprise connectivity design.
 content_sources:
   diagrams:
     - id: network-topology-map
@@ -37,7 +38,15 @@ flowchart TD
     E -->|No| G[Service Endpoint]
 ```
 
-## Microsoft Learn references
+## See Also
+
+- [Architecture Decision Matrix](architecture-decision-matrix.md) — workload-to-service selection and sibling deep-guide entry points
+- [Series Portal](series-portal.md) — route to a sibling deep-guide once the service is chosen
+- [Compute Selection Cheatsheet](compute-selection-cheatsheet.md) — narrow compute options
+- [Data Selection Cheatsheet](data-selection-cheatsheet.md) — narrow data platform options
+- [Messaging Selection Cheatsheet](messaging-selection-cheatsheet.md) — narrow messaging primitives
+
+## Sources
 
 - https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/

--- a/docs/reference/series-portal.md
+++ b/docs/reference/series-portal.md
@@ -16,6 +16,9 @@ Once an architecture decision has narrowed the workload to a specific Azure serv
 
 Each entry links to a companion practical guide that follows the same core structure documented in the [Series Lab Contract](../contributing/series-lab-contract.md): Start Here → Platform → Best Practices → Operations → Troubleshooting → Reference.
 
+!!! tip "Still choosing a service? Start with the matrix"
+    This portal assumes the service is already chosen. If you are still deciding *which* Azure service fits the workload, start with the [Architecture Decision Matrix](architecture-decision-matrix.md) — it maps workload types to service combinations and hands off to the same sibling deep-guides listed below.
+
 ## When to use this portal
 
 - You already know which Azure service the workload will run on. [Documented]


### PR DESCRIPTION
## Summary

Implements **P1a** from meta-tracker #34 (cross-repo service-selection matrix). Following the same enhance-existing-artifacts approach used in P1c, this strengthens the already-present selection surfaces rather than creating new pages.

- **architecture-decision-matrix.md**: added `description` frontmatter, a "How to use this matrix" section, and a new **Deep guide** column mapping all 7 workload rows to the corresponding sibling deep-guide scenario-router URLs. Normalized the tail to canonical `## See Also` + `## Sources`.
- **series-portal.md**: added a `!!! tip` admonition routing readers who haven't chosen a service yet back to the decision matrix.
- **4 selection cheatsheets** (compute / data / messaging / network): added per-page `description`, and normalized `## Microsoft Learn references` into canonical `## See Also` (now cross-linking the matrix, the portal, and all three sibling cheatsheets) + `## Sources`.

## Scope notes

- No new top-level sections, no nav expansion, no file renames, no new pages — per Oracle NoFix constraints. Existing pages enhanced only.
- Azure Functions deep-guide entries intentionally point at `/start-here/` (its scenario-router is deferred; see series-portal.md).

## Verification

- `mkdocs build --strict` — 0 link errors
- `validate_content_sources` / `validate_mermaid_format` / `validate_pii` / `validate_cli_flags` — all pass

## Follow-up (pre-existing, not introduced here)

`scripts/validate_mslearn_urls.py` crashes on `origin/main` (list-form `content_sources` bug), unrelated to this change. Flagging for a separate follow-up issue.