### PR TITLE
docs(AGENTS): reconcile content-validation policy with actual provenance model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -557,39 +557,20 @@ content_sources:
 
 ### Text Content Validation
 
-Every non-tutorial document should include a `content_validation` block in frontmatter to track the verification status of its core claims.
+This repository does **not** use per-file `content_validation` frontmatter blocks. Provenance and factual traceability are enforced through a lighter model:
 
-```yaml
----
-content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/architecture/...
-content_validation:
-  status: verified  # verified | pending_review | unverified
-  last_reviewed: 2026-04-12
-  reviewer: agent  # agent | human
-  core_claims:
-    - claim: "{example claim}"
-      source: https://learn.microsoft.com/azure/architecture/...
-      verified: true
----
-```
+1. **Per-diagram / per-page provenance** via `content_sources` frontmatter (see [Diagram Source Documentation](#diagram-source-documentation)), enforced by `scripts/validate_content_sources.py`.
+2. **Microsoft Learn URL health** enforced by `scripts/validate_mslearn_urls.py`.
+3. **Section-level review tracking** via the manually maintained [Content Validation Status](docs/reference/content-validation-status.md) dashboard, which records source coverage, diagram metadata, and evidence tagging status per major section.
 
-#### Validation Status Values
+!!! note "Cross-repo divergence"
+    The sibling **container-apps** guide DOES enforce a per-file `content_validation` core-claims policy with a generator script. This architecture repository deliberately does not, because its section-level dashboard plus `content_sources`/`validate_mslearn_urls` gates already provide sufficient, low-maintenance provenance for a solo-maintained series. Do not add per-file `content_validation` blocks or a `generate_content_validation_status.py` generator here without first raising a policy issue — a repo whose `docs/` currently contains zero such blocks should stay that way.
 
-| Status | Description |
-|--------|-------------|
-| `verified` | All core claims have been traced to Microsoft Learn sources |
-| `pending_review` | Document exists but claims need source verification |
-| `unverified` | New document, no validation performed |
+#### Agent Rules for Content Provenance
 
-#### Agent Rules for Content Validation
-
-1. When creating or modifying Platform, Best Practices, or Operations documents, add `content_validation` frontmatter.
-2. List 2-5 core claims that are factual assertions (not opinions or procedures).
-3. Each claim must have a Microsoft Learn source URL.
-4. Set `status: verified` only when ALL core claims have verified sources.
-5. Run `python3 scripts/generate_content_validation_status.py` after updates.
+1. When creating or modifying Platform, WAF, Patterns, Workload Guides, or Operations documents, ensure `content_sources` frontmatter is present and each Microsoft Learn URL materially supports the page or its diagrams.
+2. Run `python3 scripts/validate_content_sources.py` and `python3 scripts/validate_mslearn_urls.py` after updates; both must pass.
+3. When a section's coverage or review posture changes materially, update the section row in `docs/reference/content-validation-status.md` by hand. It is intentionally not auto-generated.
 
 ## Quality Gates & Verification
 


### PR DESCRIPTION
## Summary

Reconciles the `AGENTS.md` "Text Content Validation" section with the repository's actual provenance model, per the Option B decision on #12.

The old section instructed agents to add per-file `content_validation` frontmatter blocks to every non-tutorial doc and to run `scripts/generate_content_validation_status.py`. Neither reflects reality:

- `grep -rl "content_validation:" docs/` → **0 files**. No doc in this repo has ever carried a per-file `content_validation` block on `main`.
- `scripts/generate_content_validation_status.py` **does not exist** in this repo.

Following those stale instructions would recreate the exact obsolete problem #12 describes (bulk-generated generic core_claims targeting artifacts that were never merged).

## What changed

- Documents the real model: `content_sources` provenance (`validate_content_sources.py`) + Microsoft Learn URL health (`validate_mslearn_urls.py`) + the manually maintained section-level [`content-validation-status.md`](docs/reference/content-validation-status.md) dashboard.
- Adds an explicit **cross-repo divergence note**: the container-apps sibling DOES enforce per-file `content_validation`; this repo deliberately does not. Prevents future agents from misapplying the sibling's policy here.
- Replaces "Agent Rules for Content Validation" with "Agent Rules for Content Provenance" pointing at the two validators that actually run in CI.

## Verification

- `python3 scripts/validate_content_sources.py` → PASS (117 files, 0 errors)
- `mkdocs build --strict` → PASS (exit 0)
- Diff is docs-only: 10 insertions, 29 deletions in `AGENTS.md`.

Refs #12.