### PR TITLE
docs(platform): add See Also cross-links to platform pages (#12)

### DIFF
--- a/docs/platform/azure-architecture-on-azure.md
+++ b/docs/platform/azure-architecture-on-azure.md
@@ -100,6 +100,12 @@ Ask these before moving into workload design:
 3. Are control-plane and data-plane permissions separately reviewed?
 4. Does the selected region support the service capabilities the architecture depends on?
 
+## See Also
+
+- [Resource Organization](resource-organization.md) — the management hierarchy that sits on the ARM control plane
+- [Landing Zones Basics](landing-zones-basics.md) — how shared platform services are owned separately from workloads
+- [Resilience and Region Strategy](resilience-and-region-strategy.md) — turning regions and zones into deliberate failure domains
+
 ## Microsoft Learn anchors
 
 - [Azure Architecture Guide](https://learn.microsoft.com/en-us/azure/architecture/guide/)

--- a/docs/platform/compute-selection-basics.md
+++ b/docs/platform/compute-selection-basics.md
@@ -88,6 +88,12 @@ flowchart TD
 3. What is the expected burst pattern and steady-state utilization?
 4. How much platform complexity can the organization sustainably operate?
 
+## See Also
+
+- [Data Selection Basics](data-selection-basics.md) — the paired data-store decision for the same workload
+- [Integration Selection Basics](integration-selection-basics.md) — how components communicate once compute is chosen
+- [Network Topology Basics](network-topology-basics.md) — the connectivity model the chosen compute must fit
+
 ## Microsoft Learn anchors
 
 - [Compute decision tree](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree)

--- a/docs/platform/cost-model-basics.md
+++ b/docs/platform/cost-model-basics.md
@@ -88,6 +88,12 @@ The right question is whether spend is aligned to business value, risk posture, 
 3. Which SKUs were selected for a measured reason versus inherited default?
 4. What is the plan for budget visibility and anomaly detection?
 
+## See Also
+
+- [Compute Selection Basics](compute-selection-basics.md) — how scaling model and idle capacity drive spend
+- [Resource Organization](resource-organization.md) — subscription boundaries as billing and cost-allocation units
+- [Observability Foundations](observability-foundations.md) — telemetry retention as a recurring cost lever
+
 ## Microsoft Learn anchors
 
 - [Cost Management and Billing overview](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/overview-cost-management)

--- a/docs/platform/data-selection-basics.md
+++ b/docs/platform/data-selection-basics.md
@@ -79,6 +79,12 @@ flowchart TD
 3. What is the expected partition key or data distribution strategy?
 4. How do latency and cost change when replication or retention grows?
 
+## See Also
+
+- [Compute Selection Basics](compute-selection-basics.md) — the paired compute decision for the same workload
+- [Integration Selection Basics](integration-selection-basics.md) — how data moves between components and systems
+- [Resilience and Region Strategy](resilience-and-region-strategy.md) — replication and RPO implications of the chosen data store
+
 ## Microsoft Learn anchors
 
 - [Choose a data store](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/data-store-overview)

--- a/docs/platform/identity-and-governance-foundations.md
+++ b/docs/platform/identity-and-governance-foundations.md
@@ -97,6 +97,12 @@ Architectural implications:
 3. How do workloads authenticate to Azure services without embedding secrets broadly?
 4. Who approves and revisits governance exceptions?
 
+## See Also
+
+- [Resource Organization](resource-organization.md) — the scopes that RBAC and policy assignments bind to
+- [Landing Zones Basics](landing-zones-basics.md) — how the governance baseline is packaged into the platform layer
+- [Azure Architecture on Azure](azure-architecture-on-azure.md) — control-plane versus data-plane authorization boundaries
+
 ## Microsoft Learn anchors
 
 - [Azure RBAC overview](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview)

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -78,6 +78,13 @@ It does not try to cover:
 - runtime tuning detail for specific SKUs
 - feature matrices better maintained in product documentation
 
+## See Also
+
+- [Start Here](../start-here/index.md) — orientation and reading paths before diving into platform fundamentals
+- [Well-Architected](../waf/index.md) — how the five pillars build on these platform foundations
+- [Patterns](../patterns/index.md) — reusable design patterns that assume the platform decisions in this section
+- [Workload Guides](../workload-guides/index.md) — workload baselines that inherit these platform choices
+
 ## Microsoft Learn anchors
 
 - [Azure Architecture Guide](https://learn.microsoft.com/en-us/azure/architecture/guide/)

--- a/docs/platform/integration-selection-basics.md
+++ b/docs/platform/integration-selection-basics.md
@@ -77,6 +77,12 @@ flowchart TD
 3. Is ordering required globally, per entity, or not at all?
 4. Who owns replay, poison-message handling, and consumer lag visibility?
 
+## See Also
+
+- [Compute Selection Basics](compute-selection-basics.md) — the services that produce and consume these messages
+- [Data Selection Basics](data-selection-basics.md) — where integrated data lands and becomes source of truth
+- [Observability Foundations](observability-foundations.md) — consumer lag, dead-letter, and telemetry for messaging paths
+
 ## Microsoft Learn anchors
 
 - [Choose a messaging service](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/messaging)

--- a/docs/platform/landing-zones-basics.md
+++ b/docs/platform/landing-zones-basics.md
@@ -86,6 +86,12 @@ flowchart TD
 !!! tip
     If a design choice affects many workloads, make it part of the landing zone. If it only affects one workload, keep it in the application boundary unless policy says otherwise.
 
+## See Also
+
+- [Resource Organization](resource-organization.md) — the management hierarchy that anchors the platform layer
+- [Identity and Governance Foundations](identity-and-governance-foundations.md) — the identity and policy baseline a landing zone standardizes
+- [Network Topology Basics](network-topology-basics.md) — the shared connectivity services owned by the platform team
+
 ## Microsoft Learn anchors
 
 - [Cloud Adoption Framework landing zones](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/)

--- a/docs/platform/network-topology-basics.md
+++ b/docs/platform/network-topology-basics.md
@@ -98,6 +98,12 @@ Design questions include:
 3. Where are the forced-routing and inspection choke points?
 4. What is the blast radius if the central networking layer fails or misroutes traffic?
 
+## See Also
+
+- [Landing Zones Basics](landing-zones-basics.md) — how shared connectivity is owned in the platform layer
+- [Compute Selection Basics](compute-selection-basics.md) — the workloads that consume this connectivity fabric
+- [Resilience and Region Strategy](resilience-and-region-strategy.md) — how topology supports multi-region routing and failover
+
 ## Microsoft Learn anchors
 
 - [Azure networking architecture design](https://learn.microsoft.com/en-us/azure/architecture/networking/)

--- a/docs/platform/observability-foundations.md
+++ b/docs/platform/observability-foundations.md
@@ -81,6 +81,12 @@ flowchart TD
 3. Which telemetry is mandatory across all subscriptions or landing zones?
 4. Who owns alert quality and ongoing tuning?
 
+## See Also
+
+- [Resilience and Region Strategy](resilience-and-region-strategy.md) — the detection signals and drill evidence resilience depends on
+- [Cost Model Basics](cost-model-basics.md) — how telemetry volume and retention become billable behavior
+- [Compute Selection Basics](compute-selection-basics.md) — the workloads that must be instrumented end to end
+
 ## Microsoft Learn anchors
 
 - [Azure Monitor overview](https://learn.microsoft.com/en-us/azure/azure-monitor/overview)

--- a/docs/platform/resilience-and-region-strategy.md
+++ b/docs/platform/resilience-and-region-strategy.md
@@ -78,6 +78,12 @@ Architectural consequences include:
 3. How will traffic, state, secrets, and operational access behave during failover?
 4. When was the last recovery drill and what evidence proved the targets?
 
+## See Also
+
+- [Azure Architecture on Azure](azure-architecture-on-azure.md) — regions, zones, and edge as the underlying failure domains
+- [Network Topology Basics](network-topology-basics.md) — routing and connectivity for multi-region designs
+- [Observability Foundations](observability-foundations.md) — detection and drill evidence that validate recovery targets
+
 ## Microsoft Learn anchors
 
 - [Azure reliability overview](https://learn.microsoft.com/en-us/azure/reliability/overview)

--- a/docs/platform/resource-organization.md
+++ b/docs/platform/resource-organization.md
@@ -125,6 +125,12 @@ Minimum useful tag set for most estates:
 3. Which resources are expected to share lifecycle and RBAC boundaries?
 4. Can an operator infer owner, environment, and purpose from the naming standard?
 
+## See Also
+
+- [Landing Zones Basics](landing-zones-basics.md) — the platform baseline that consumes this hierarchy
+- [Identity and Governance Foundations](identity-and-governance-foundations.md) — RBAC and policy scoped to management groups, subscriptions, and resource groups
+- [Cost Model Basics](cost-model-basics.md) — how subscription boundaries shape billing and cost visibility
+
 ## Microsoft Learn anchors
 
 - [Organize your Azure resources](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-setup-guide/organize-resources)


### PR DESCRIPTION
## Summary

Adds a `## See Also` section to all 12 `docs/platform/` pages, closing the largest gap found in the #12 content audit (101 of 117 docs were missing the `## See Also` tail section required by AGENTS.md).

This is the **pilot batch** (platform section) of a section-by-section rollout across the remaining ~89 pages.

## Details

- Each page gets 3 curated intra-repo cross-links (section `index.md` gets 4 cross-section links), chosen for genuine concept adjacency — not mechanical "related pages" filler.
- Links are inserted before the existing `## Microsoft Learn anchors` block, preserving the AGENTS.md tail order (internal links → external sources).
- No frontmatter, body prose, or `mkdocs.yml` nav changes.

## Verification

- `mkdocs build --strict` → exit 0, no broken-link warnings
- `scripts/validate_content_sources.py` → 117 files, 0 errors
- Diff: 12 files, +73 insertions only

Part of #12.