### PR TITLE
docs(design-labs): add See Also cross-links to design-labs pages (#12)

### DIFF
--- a/docs/design-labs/index.md
+++ b/docs/design-labs/index.md
@@ -63,6 +63,12 @@ Use the evidence tags consistently:
 - **Assumed** when validation is still pending.
 - **Unknown** when evidence is missing.
 
+## See Also
+
+- [Design Lab Methodology](methodology.md) — the ADVR structure every lab follows
+- [Workload Guides](../workload-guides/index.md) — the implementation blueprints each lab pairs with
+- [Patterns](../patterns/index.md) — reusable design patterns referenced across the labs
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/

--- a/docs/design-labs/lab-01-public-web-baseline.md
+++ b/docs/design-labs/lab-01-public-web-baseline.md
@@ -120,6 +120,12 @@ For a public-facing Azure web application, Front Door plus zone-redundant App Se
 
 No cleanup is required. This design lab is a paper exercise; no Azure resources were provisioned.
 
+## See Also
+
+- [Public Web and API workload guide](../workload-guides/public-web-api/index.md) — the paired implementation blueprint for this decision
+- [Public Web and API baseline](../workload-guides/public-web-api/baseline.md) — detailed baseline architecture and standards
+- [Design Lab Methodology](methodology.md) — the ADVR structure this lab follows
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/web-apps/app-service/architectures/baseline-zone-redundant

--- a/docs/design-labs/lab-02-private-internal-app.md
+++ b/docs/design-labs/lab-02-private-internal-app.md
@@ -122,6 +122,12 @@ For a private internal Azure application, App Service Private Endpoint for ingre
 
 No cleanup is required. This design lab is a paper exercise; no Azure resources were provisioned.
 
+## See Also
+
+- [Private Internal App workload guide](../workload-guides/private-internal-app/index.md) — the paired implementation blueprint for this decision
+- [Private Internal App network and access](../workload-guides/private-internal-app/network-and-access.md) — private ingress, endpoints, and DNS detail
+- [Network Topology Basics](../platform/network-topology-basics.md) — the private endpoint and DNS concepts this lab depends on
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview

--- a/docs/design-labs/lab-03-event-driven-orders.md
+++ b/docs/design-labs/lab-03-event-driven-orders.md
@@ -120,6 +120,12 @@ For event-driven order processing on Azure, Service Bus plus Functions, Cosmos D
 
 No cleanup is required. This design lab is a paper exercise; no Azure resources were provisioned.
 
+## See Also
+
+- [Event-Driven Integration workload guide](../workload-guides/event-driven-integration/index.md) — the paired implementation blueprint for this decision
+- [Event-Driven messaging and consistency](../workload-guides/event-driven-integration/messaging-and-consistency.md) — delivery guarantees, idempotency, and consistency detail
+- [Integration Selection Basics](../platform/integration-selection-basics.md) — choosing between messaging, eventing, and streaming
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven

--- a/docs/design-labs/methodology.md
+++ b/docs/design-labs/methodology.md
@@ -96,6 +96,12 @@ Choose Option B because ...
 - Link the lab to the matching workload guide and infrastructure path when available.
 - Mark unresolved points as [Assumed] or [Unknown] instead of hiding uncertainty.
 
+## See Also
+
+- [Design Labs](index.md) — the labs that apply this ADVR method
+- [Well-Architected](../waf/index.md) — the quality-attribute pillars that drive ADVR priority ranking
+- [Patterns](../patterns/index.md) — candidate options and trade-offs expressed as reusable patterns
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/


### PR DESCRIPTION
## Summary

Adds a `## See Also` section to all 5 `docs/design-labs/` pages, continuing the section-by-section rollout that closes the #12 audit gap (101 of 117 docs missing `## See Also`).

## Details

- Each lab links to its paired workload guide (and the specific sub-page for network/messaging detail) plus the platform concept it depends on.
- The section index and methodology pages link to Workload Guides, Patterns, and Well-Architected.
- Links inserted before the existing `## Microsoft Learn references` block; no frontmatter, body, or nav changes.

## Verification

- `mkdocs build --strict` → exit 0, no broken-link warnings
- Diff: 5 files, +30 insertions only

Part of #12. Follows #59 (platform batch).