### PR TITLE
docs(start-here): add See Also to remaining start-here pages (#12)

### DIFF
--- a/docs/start-here/architecture-vs-service-guides.md
+++ b/docs/start-here/architecture-vs-service-guides.md
@@ -91,6 +91,12 @@ Examples:
 - [Architecture guide](https://learn.microsoft.com/en-us/azure/architecture/guide/)
 - [App Service documentation](https://learn.microsoft.com/en-us/azure/app-service/)
 
+## See Also
+
+- [Overview](overview.md) — what this guide is for and how it differs from Microsoft Learn
+- [How to Use This Guide](how-to-use-this-guide.md) — pairing architecture decisions with service configuration sources
+- [Platform Hub](../platform/index.md) — the architecture-first foundations this guide prioritizes
+
 ## Takeaway
 
 [Inferred] This guide should answer architecture questions that remain valid even if Microsoft changes a portal workflow or CLI parameter.

--- a/docs/start-here/how-to-use-this-guide.md
+++ b/docs/start-here/how-to-use-this-guide.md
@@ -121,6 +121,13 @@ At that point, use Microsoft Learn for the product facts, then return to this gu
 - [Architecture guide](https://learn.microsoft.com/en-us/azure/architecture/guide/)
 - [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)
 
+## See Also
+
+- [Overview](overview.md) — scope, audience, and the evidence model
+- [Learning Paths](learning-paths.md) — role-based reading order
+- [Repository Map](repository-map.md) — full section map
+- [Platform Hub](../platform/index.md) — the foundational decisions to read first
+
 ## Takeaway
 
 [Inferred] The best use of this guide is iterative.

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -81,6 +81,14 @@ This section should not spend most of its space on:
 - [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)
 - [Azure Architecture Guide](https://learn.microsoft.com/en-us/azure/architecture/guide/)
 
+## See Also
+
+- [Overview](overview.md) — scope, audience, and the evidence model used throughout
+- [Learning Paths](learning-paths.md) — role-based reading order
+- [How to Use This Guide](how-to-use-this-guide.md) — how the sections connect and pair with Microsoft Learn
+- [Repository Map](repository-map.md) — full documentation structure
+- [Platform Hub](../platform/index.md) — the recommended first destination after this section
+
 ## Takeaway
 
 [Inferred] Treat Start Here as the map, not the destination.


### PR DESCRIPTION
## Summary

Adds `## See Also` to the 3 `docs/start-here/` pages that were missing it (`index.md`, `how-to-use-this-guide.md`, `architecture-vs-service-guides.md`). The other 4 start-here pages already had the section.

## Details

- Matches the existing start-here convention (See Also placed after the Learn anchors, before `## Takeaway`).
- Links point to sibling orientation pages and the Platform hub as the recommended first destination.
- No frontmatter, body, or nav changes.

## Verification

- `mkdocs build --strict` → exit 0, no broken-link warnings
- Diff: 3 files, +21 insertions only

Part of #12. Follows #59 (platform) and #60 (design-labs).