### PR TITLE
docs(reference): add See Also to reference pages (#12)

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -86,6 +86,12 @@ flowchart TD
     E --> E2[Strangler Fig]
 ```
 
+## See Also
+
+- [Platform concepts](../platform/index.md)
+- [Design patterns](../patterns/index.md)
+- [WAF pillar to pattern map](waf-pillar-to-pattern-map.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -43,6 +43,12 @@ flowchart TD
     D --> E[Validation tracking]
 ```
 
+## See Also
+
+- [Architecture decision matrix](architecture-decision-matrix.md)
+- [Platform concepts](../platform/index.md)
+- [Design labs](../design-labs/index.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/

--- a/docs/reference/resilience-targets-rto-rpo.md
+++ b/docs/reference/resilience-targets-rto-rpo.md
@@ -48,6 +48,12 @@ flowchart TD
     E --> G[Failover automation and exercises]
 ```
 
+## See Also
+
+- [Resilience and region strategy](../platform/resilience-and-region-strategy.md)
+- [WAF reliability pillar](../waf/reliability.md)
+- [Design labs](../design-labs/index.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/reliability/overview

--- a/docs/reference/security-control-mapping.md
+++ b/docs/reference/security-control-mapping.md
@@ -65,6 +65,12 @@ flowchart TD
     E --> E2[Microsoft Sentinel]
 ```
 
+## See Also
+
+- [Identity and governance foundations](../platform/identity-and-governance-foundations.md)
+- [WAF security pillar](../waf/security.md)
+- [Identity-first and secrets flow](../patterns/security/identity-first-and-secrets-flow.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/well-architected/security/

--- a/docs/reference/source-index.md
+++ b/docs/reference/source-index.md
@@ -78,6 +78,12 @@ flowchart TD
     A --> F[Operations]
 ```
 
+## See Also
+
+- [Reference overview](index.md)
+- [Platform concepts](../platform/index.md)
+- [Design patterns](../patterns/index.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/

--- a/docs/reference/waf-pillar-to-pattern-map.md
+++ b/docs/reference/waf-pillar-to-pattern-map.md
@@ -32,6 +32,12 @@ flowchart TD
     C --> D[Validate with lab or review]
 ```
 
+## See Also
+
+- [Well-Architected Framework](../waf/index.md)
+- [Design patterns](../patterns/index.md)
+- [Design labs methodology](../design-labs/methodology.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/well-architected/


### PR DESCRIPTION
## Summary
- Adds the AGENTS.md-required `## See Also` tail section to 6 editable `docs/reference/` pages.
- Skips the two auto-generated dashboards (`content-validation-status.md`, `validation-status.md`) per AGENTS.md (must not be hand-edited).

## Details
Each page gains 3 curated intra-repo cross-links placed immediately before `## Microsoft Learn references`:
- `index.md` → decision matrix, platform, design labs
- `glossary.md` → platform, patterns, WAF pattern map
- `resilience-targets-rto-rpo.md` → resilience strategy, WAF reliability, design labs
- `security-control-mapping.md` → identity foundations, WAF security, identity-first pattern
- `source-index.md` → reference overview, platform, patterns
- `waf-pillar-to-pattern-map.md` → WAF, patterns, design labs methodology

## Verification
- `mkdocs build --strict` exit 0, no broken links
- `scripts/validate_content_sources.py` — 0 errors
- diff: +36 lines across 6 files, See Also only

Part of #12. Follows #59 (platform), #60 (design-labs), #61 (start-here).