### PR TITLE
docs(operations): add See Also to operations pages (#12)

### DIFF
--- a/docs/operations/adr-process.md
+++ b/docs/operations/adr-process.md
@@ -89,6 +89,12 @@ Create ADRs for platform baselines, identity boundaries, region strategy, deploy
 
 [Inferred] A strong ADR is short enough to be read during a design review but specific enough to survive team turnover. If readers cannot tell why a choice was made or what would invalidate it, the record is incomplete.
 
+## See Also
+
+- [Architecture lifecycle](architecture-lifecycle.md)
+- [Architecture decision matrix](../reference/architecture-decision-matrix.md)
+- [Policy and governance guardrails](policy-and-governance-guardrails.md)
+
 ## Microsoft Learn references
 
 - [Azure Architecture Center patterns](https://learn.microsoft.com/en-us/azure/architecture/patterns/)

--- a/docs/operations/architecture-lifecycle.md
+++ b/docs/operations/architecture-lifecycle.md
@@ -82,6 +82,12 @@ flowchart TD
 - Has the workload outgrown its original scaling, security, or team model?
 - What decisions are becoming expensive to reverse?
 
+## See Also
+
+- [ADR process](adr-process.md)
+- [Design labs methodology](../design-labs/methodology.md)
+- [Observability and SLOs](observability-and-slos.md)
+
 ## Microsoft Learn references
 
 - [Cloud Adoption Framework](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/)

--- a/docs/operations/business-continuity-and-drills.md
+++ b/docs/operations/business-continuity-and-drills.md
@@ -88,6 +88,12 @@ Plan drills that move beyond control-plane success:
 - [Correlated] Incident findings influence continuity architecture.
 - [Unknown] Untested recovery paths are tracked as risk.
 
+## See Also
+
+- [Resilience and region strategy](../platform/resilience-and-region-strategy.md)
+- [Resilience targets (RTO/RPO)](../reference/resilience-targets-rto-rpo.md)
+- [WAF reliability pillar](../waf/reliability.md)
+
 ## Microsoft Learn references
 
 - [Business continuity management program guidance](https://learn.microsoft.com/en-us/azure/reliability/business-continuity-management-program)

--- a/docs/operations/cost-management-and-finops.md
+++ b/docs/operations/cost-management-and-finops.md
@@ -90,6 +90,12 @@ These commitment models are valuable when demand is stable enough. The architect
 - [Correlated] Cost anomalies are linked to traffic, releases, or topology changes.
 - [Inferred] FinOps insights influence architecture reviews and backlog priorities.
 
+## See Also
+
+- [WAF cost optimization pillar](../waf/cost-optimization.md)
+- [Observability and SLOs](observability-and-slos.md)
+- [Design patterns](../patterns/index.md)
+
 ## Microsoft Learn references
 
 - [Azure Cost Management and Billing documentation](https://learn.microsoft.com/en-us/azure/cost-management-billing/)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -64,7 +64,7 @@ This section intentionally stays architectural. It explains how to choose operat
 
 Read the section in operating order rather than alphabetical order. Start with lifecycle and ADRs to understand how decisions are recorded, then move into IaC, policy, and observability to see how those decisions are enforced. Finish with continuity, FinOps, and team-topology guidance to confirm the architecture can survive failure, growth, and organizational change.
 
-## Related pages
+## See Also
 
 - [Architecture lifecycle](architecture-lifecycle.md)
 - [ADR process](adr-process.md)

--- a/docs/operations/infrastructure-as-code-and-environment-promotion.md
+++ b/docs/operations/infrastructure-as-code-and-environment-promotion.md
@@ -85,6 +85,12 @@ flowchart TD
 - [Correlated] Production deployment issues are traced back to template or promotion design.
 - [Inferred] Module reuse reduces inconsistent implementation of core controls.
 
+## See Also
+
+- [Environment promotion and release guardrails](../patterns/deployment/environment-promotion-and-release-guardrails.md)
+- [Policy and governance guardrails](policy-and-governance-guardrails.md)
+- [Architecture lifecycle](architecture-lifecycle.md)
+
 ## Microsoft Learn references
 
 - [Bicep overview](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)

--- a/docs/operations/observability-and-slos.md
+++ b/docs/operations/observability-and-slos.md
@@ -92,6 +92,12 @@ Avoid vanity SLOs that are easy to meet but weakly tied to actual user impact.
 - [Correlated] Telemetry joins application, dependency, and platform signals.
 - [Inferred] Observability backlog exists for blind spots and noisy alerts.
 
+## See Also
+
+- [WAF operational excellence pillar](../waf/operational-excellence.md)
+- [Business continuity and drills](business-continuity-and-drills.md)
+- [Platform concepts](../platform/index.md)
+
 ## Microsoft Learn references
 
 - [Azure Monitor overview](https://learn.microsoft.com/en-us/azure/azure-monitor/overview)

--- a/docs/operations/platform-team-vs-app-team-responsibilities.md
+++ b/docs/operations/platform-team-vs-app-team-responsibilities.md
@@ -81,6 +81,12 @@ Use clear interfaces:
 - [Correlated] Platform roadmap changes respond to recurring app-team friction.
 - [Inferred] Shared responsibility reduces ambiguity without diluting accountability.
 
+## See Also
+
+- [Architecture lifecycle](architecture-lifecycle.md)
+- [Policy and governance guardrails](policy-and-governance-guardrails.md)
+- [ADR process](adr-process.md)
+
 ## Microsoft Learn references
 
 - [Cloud Adoption Framework organize guidance](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/organize/)

--- a/docs/operations/policy-and-governance-guardrails.md
+++ b/docs/operations/policy-and-governance-guardrails.md
@@ -82,6 +82,12 @@ flowchart TD
 - [Correlated] Repeated exception patterns trigger architecture or platform changes.
 - [Unknown] Any control without owner or escalation path is flagged.
 
+## See Also
+
+- [Identity and governance foundations](../platform/identity-and-governance-foundations.md)
+- [Infrastructure as code and environment promotion](infrastructure-as-code-and-environment-promotion.md)
+- [WAF security pillar](../waf/security.md)
+
 ## Microsoft Learn references
 
 - [Azure Policy overview](https://learn.microsoft.com/en-us/azure/governance/policy/overview)


### PR DESCRIPTION
## Summary
Adds the AGENTS.md-required `## See Also` tail section to all 9 `docs/operations/` pages.

## Details
`index.md` renames its existing `## Related pages` block to `## See Also` (AGENTS-compliant heading). The other 8 pages gain 3 curated intra-repo cross-links placed immediately before `## Microsoft Learn references`, keeping the closing `## Takeaway` last (consistent with PR #59 placement):
- adr-process → lifecycle, decision matrix, policy guardrails
- architecture-lifecycle → ADR, design labs methodology, observability
- business-continuity-and-drills → resilience strategy, RTO/RPO targets, WAF reliability
- cost-management-and-finops → WAF cost, observability, patterns
- infrastructure-as-code-and-environment-promotion → env promotion pattern, policy guardrails, lifecycle
- observability-and-slos → WAF operational excellence, continuity, platform
- platform-team-vs-app-team-responsibilities → lifecycle, policy guardrails, ADR
- policy-and-governance-guardrails → identity foundations, IaC, WAF security

## Verification
- `mkdocs build --strict` exit 0, no broken links
- `scripts/validate_content_sources.py` — all validations passed
- diff: +49 / -1 across 9 files, See Also only

Part of #12. Follows #59, #60, #61, #62.