### PR TITLE
docs(waf): add See Also to WAF pages (#12)

### DIFF
--- a/docs/waf/architecture-assessment-checklist.md
+++ b/docs/waf/architecture-assessment-checklist.md
@@ -116,6 +116,12 @@ Use the official assessment as a structured complement to human review, not a su
 - [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)
 - [Azure Architecture Review assessment](https://learn.microsoft.com/en-us/assessments/azure-architecture-review/)
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [Design labs methodology](../design-labs/methodology.md)
+- [Architecture decision matrix](../reference/architecture-decision-matrix.md)
+
 ## Takeaway
 
 [Validated] A strong architecture review produces clear evidence, named owners, and validation plans across all five pillars instead of a generic statement that the design is "well architected."

--- a/docs/waf/cost-optimization.md
+++ b/docs/waf/cost-optimization.md
@@ -100,6 +100,12 @@ Cost optimization should be shared:
 
 Ask whether the architecture can degrade gracefully in cost as well as scale gracefully in demand. Good designs let teams lower spend without rewriting the workload. That usually means modular scaling boundaries, intentional telemetry retention, clear environment strategy, and visible service ownership.
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [Pillar trade-offs](pillar-trade-offs.md)
+- [Cost management and FinOps](../operations/cost-management-and-finops.md)
+
 ## Microsoft Learn references
 
 - [Cost Optimization pillar](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/waf/index.md
+++ b/docs/waf/index.md
@@ -86,6 +86,12 @@ Architectures should leave this section with explicit validation paths:
 - [Pillar trade-offs](pillar-trade-offs.md)
 - [Architecture assessment checklist](architecture-assessment-checklist.md)
 
+## See Also
+
+- [Using WAF in this guide](using-waf-in-this-guide.md)
+- [WAF pillar to pattern map](../reference/waf-pillar-to-pattern-map.md)
+- [Design patterns](../patterns/index.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)

--- a/docs/waf/operational-excellence.md
+++ b/docs/waf/operational-excellence.md
@@ -92,6 +92,12 @@ flowchart TD
 
 Validate operational excellence through release simulations, drift detection, incident exercises, and alert reviews. If a team cannot explain how a change moves from source to safe production rollback, the architecture is not yet operationally sound.
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [Observability and SLOs](../operations/observability-and-slos.md)
+- [Reliability pillar](reliability.md)
+
 ## Microsoft Learn references
 
 - [Operational Excellence pillar](https://learn.microsoft.com/en-us/azure/well-architected/operational-excellence/)

--- a/docs/waf/performance-efficiency.md
+++ b/docs/waf/performance-efficiency.md
@@ -91,6 +91,12 @@ Performance is shared across app, data, and platform teams:
 
 Use scenario-based validation: launch spikes, batch overlap, tenant skew, degraded dependency performance, and failover conditions. If performance expectations only hold in the happy path, the architecture is fragile.
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [Design patterns](../patterns/index.md)
+- [Pillar trade-offs](pillar-trade-offs.md)
+
 ## Microsoft Learn references
 
 - [Performance Efficiency pillar](https://learn.microsoft.com/en-us/azure/well-architected/performance-efficiency/)

--- a/docs/waf/pillar-trade-offs.md
+++ b/docs/waf/pillar-trade-offs.md
@@ -102,6 +102,12 @@ Use a simple prioritization sequence:
 - [Inferred] Deferred improvements include explicit revisit triggers.
 - [Unknown] Any unowned trade-off is a governance gap.
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [WAF pillar to pattern map](../reference/waf-pillar-to-pattern-map.md)
+- [Design labs methodology](../design-labs/methodology.md)
+
 ## Microsoft Learn references
 
 - [Well-Architected pillars](https://learn.microsoft.com/en-us/azure/well-architected/pillars)

--- a/docs/waf/reliability.md
+++ b/docs/waf/reliability.md
@@ -90,6 +90,12 @@ Reliability reviews should name and validate both:
 
 Run tabletop reviews, backup restorations, zonal failure simulations, dependency throttling tests, and failover exercises. Reliability without drills is mostly [Assumed].
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [Resilience and region strategy](../platform/resilience-and-region-strategy.md)
+- [Business continuity and drills](../operations/business-continuity-and-drills.md)
+
 ## Microsoft Learn references
 
 - [Reliability pillar](https://learn.microsoft.com/en-us/azure/well-architected/reliability/)

--- a/docs/waf/security.md
+++ b/docs/waf/security.md
@@ -89,6 +89,12 @@ flowchart TD
 
 Validate through access reviews, secret rotation drills, policy compliance checks, penetration testing where appropriate, and post-incident learning. A control that exists but is not reviewed or exercised remains only partially trusted.
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [Identity and governance foundations](../platform/identity-and-governance-foundations.md)
+- [Identity-first and secrets flow](../patterns/security/identity-first-and-secrets-flow.md)
+
 ## Microsoft Learn references
 
 - [Security pillar](https://learn.microsoft.com/en-us/azure/well-architected/security/)

--- a/docs/waf/using-waf-in-this-guide.md
+++ b/docs/waf/using-waf-in-this-guide.md
@@ -108,6 +108,12 @@ Do not treat the assessment as a standalone approval gate. Pair it with diagrams
 
 Review at least on initial design, pre-production readiness, post-incident, and major scale or regulatory change.
 
+## See Also
+
+- [Well-Architected Framework](index.md)
+- [WAF pillar to pattern map](../reference/waf-pillar-to-pattern-map.md)
+- [Design labs](../design-labs/index.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)


### PR DESCRIPTION
## Summary
Adds the AGENTS.md-required `## See Also` tail section to all 9 `docs/waf/` pages.

## Details
Each page gains 3 curated intra-repo cross-links. Placement is immediately before `## Microsoft Learn references` (8 pages); `architecture-assessment-checklist.md` has no Learn-references block, so its See Also is inserted before the closing `## Takeaway`. Links connect each pillar to the WAF index, sibling pillars, and the relevant platform/operations/patterns/reference pages.

## Verification
- `mkdocs build --strict` exit 0, no broken links
- `scripts/validate_content_sources.py` — all validations passed
- diff: +54 across 9 files, See Also only

Part of #12. Follows #59, #60, #61, #62, #63.