### PR TITLE
docs(patterns): add See Also to pattern pages (#12)

### DIFF
--- a/docs/patterns/data/cache-aside-cqrs-and-materialized-view.md
+++ b/docs/patterns/data/cache-aside-cqrs-and-materialized-view.md
@@ -105,6 +105,12 @@ flowchart TD
 - The workload cannot tolerate asynchronous projection lag.
 - The team lacks operational ownership for cache invalidation and projection rebuilds.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Consistency, partitioning, and replication](consistency-partitioning-and-replication.md)
+- [Data selection basics](../../platform/data-selection-basics.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/cache-aside

--- a/docs/patterns/data/consistency-partitioning-and-replication.md
+++ b/docs/patterns/data/consistency-partitioning-and-replication.md
@@ -100,6 +100,12 @@ flowchart TD
 - Business stakeholders have not defined which operations truly require strong consistency.
 - The team cannot operate cross-region failover or partition hot-spot mitigation.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Cache-aside, CQRS, and materialized view](cache-aside-cqrs-and-materialized-view.md)
+- [Multi-tenant data isolation](multi-tenant-data-isolation.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/best-practices/data-partitioning

--- a/docs/patterns/data/multi-tenant-data-isolation.md
+++ b/docs/patterns/data/multi-tenant-data-isolation.md
@@ -103,6 +103,12 @@ flowchart TD
 - Regulatory demands require physically dedicated environments for every tenant.
 - The team cannot enforce tenant context consistently across synchronous and asynchronous paths.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Consistency, partitioning, and replication](consistency-partitioning-and-replication.md)
+- [Zero trust at workload level](../security/zero-trust-at-workload-level.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/multitenant/overview

--- a/docs/patterns/decomposition/bounded-contexts-and-data-ownership.md
+++ b/docs/patterns/decomposition/bounded-contexts-and-data-ownership.md
@@ -107,6 +107,12 @@ flowchart TD
 - Add anti-corruption layers where external or legacy models differ.
 - Align identity, secrets, and network access with ownership boundaries.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Modular monolith vs microservices](modular-monolith-vs-microservices.md)
+- [Strangler fig migration](strangler-fig-migration.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/microservices/model/domain-analysis

--- a/docs/patterns/decomposition/modular-monolith-vs-microservices.md
+++ b/docs/patterns/decomposition/modular-monolith-vs-microservices.md
@@ -115,6 +115,12 @@ flowchart TD
 - Scaling problems are not yet isolated to distinct capabilities.
 - The driver is organizational fashion rather than architecture evidence.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Bounded contexts and data ownership](bounded-contexts-and-data-ownership.md)
+- [Strangler fig migration](strangler-fig-migration.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/microservices/

--- a/docs/patterns/decomposition/strangler-fig-migration.md
+++ b/docs/patterns/decomposition/strangler-fig-migration.md
@@ -109,6 +109,12 @@ flowchart TD
 - Synchronization complexity exceeds the value of incremental migration.
 - The business requires immediate retirement of the legacy estate.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Modular monolith vs microservices](modular-monolith-vs-microservices.md)
+- [Bounded contexts and data ownership](bounded-contexts-and-data-ownership.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig

--- a/docs/patterns/deployment/blue-green-canary-and-stamp-patterns.md
+++ b/docs/patterns/deployment/blue-green-canary-and-stamp-patterns.md
@@ -108,6 +108,12 @@ flowchart TD
 - The team lacks telemetry needed to decide whether promotion is safe.
 - Shared data changes cannot support version overlap or gradual exposure.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Environment promotion and release guardrails](environment-promotion-and-release-guardrails.md)
+- [Infrastructure as code and environment promotion](../../operations/infrastructure-as-code-and-environment-promotion.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/aks/blue-green-deployment-for-aks

--- a/docs/patterns/deployment/environment-promotion-and-release-guardrails.md
+++ b/docs/patterns/deployment/environment-promotion-and-release-guardrails.md
@@ -97,6 +97,12 @@ flowchart TD
 - Not as a heavyweight process for trivial internal prototypes with no shared production path.
 - Not as a substitute for engineering quality when the pipeline only automates weak checks.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Blue-green, canary, and stamp patterns](blue-green-canary-and-stamp-patterns.md)
+- [Infrastructure as code and environment promotion](../../operations/infrastructure-as-code-and-environment-promotion.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/framework/mission-critical/mission-critical-deployment-testing

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -113,6 +113,12 @@ When applying any pattern in this guide, collect evidence beyond diagrams:
 - [Correlated] Signals that link architecture choices to production pain points.
 - [Unknown] Explicit gaps that still need tests or drills.
 
+## See Also
+
+- [Service selection patterns](service-selection-patterns.md)
+- [Well-Architected Framework](../waf/index.md)
+- [WAF pillar to pattern map](../reference/waf-pillar-to-pattern-map.md)
+
 ## Microsoft Learn references
 
 - https://learn.microsoft.com/en-us/azure/architecture/

--- a/docs/patterns/integration/event-driven-architecture.md
+++ b/docs/patterns/integration/event-driven-architecture.md
@@ -106,6 +106,12 @@ flowchart TD
 - The team cannot operate distributed tracing and asynchronous debugging.
 - Eventual consistency is unacceptable for the critical decision point.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Queue-based load leveling and competing consumers](queue-based-load-leveling-and-competing-consumers.md)
+- [Saga, idempotency, and outbox](saga-idempotency-and-outbox.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven

--- a/docs/patterns/integration/queue-based-load-leveling-and-competing-consumers.md
+++ b/docs/patterns/integration/queue-based-load-leveling-and-competing-consumers.md
@@ -102,6 +102,12 @@ flowchart TD
 - Every message requires global ordering.
 - The team lacks message observability and remediation processes.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Event-driven architecture](event-driven-architecture.md)
+- [Synchronous vs asynchronous](synchronous-vs-asynchronous.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/queue-based-load-leveling

--- a/docs/patterns/integration/saga-idempotency-and-outbox.md
+++ b/docs/patterns/integration/saga-idempotency-and-outbox.md
@@ -102,6 +102,12 @@ flowchart TD
 - The team cannot operate asynchronous tracing, compensation, and replay procedures.
 - Business rules cannot tolerate eventual consistency or compensation windows.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Event-driven architecture](event-driven-architecture.md)
+- [Consistency, partitioning, and replication](../data/consistency-partitioning-and-replication.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/saga

--- a/docs/patterns/integration/synchronous-vs-asynchronous.md
+++ b/docs/patterns/integration/synchronous-vs-asynchronous.md
@@ -102,6 +102,12 @@ flowchart TD
 - Can the caller tolerate duplicate delivery or out-of-order processing?
 - Who monitors stuck, dead-lettered, or replayed work?
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Event-driven architecture](event-driven-architecture.md)
+- [Queue-based load leveling and competing consumers](queue-based-load-leveling-and-competing-consumers.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply

--- a/docs/patterns/networking/hub-spoke-vs-virtual-wan.md
+++ b/docs/patterns/networking/hub-spoke-vs-virtual-wan.md
@@ -110,6 +110,12 @@ flowchart TD
 - The environment is small and cost-sensitive.
 - Highly customized transit and inspection behaviors are mandatory.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Private connectivity patterns](private-connectivity-patterns.md)
+- [Network topology basics](../../platform/network-topology-basics.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke

--- a/docs/patterns/networking/private-connectivity-patterns.md
+++ b/docs/patterns/networking/private-connectivity-patterns.md
@@ -93,6 +93,12 @@ flowchart TD
 - The team lacks DNS and network operations maturity.
 - A public endpoint with strong identity and access controls already meets the risk profile.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Hub-spoke vs Virtual WAN](hub-spoke-vs-virtual-wan.md)
+- [Zero trust at workload level](../security/zero-trust-at-workload-level.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview

--- a/docs/patterns/resilience/health-endpoints-graceful-degradation-and-backpressure.md
+++ b/docs/patterns/resilience/health-endpoints-graceful-degradation-and-backpressure.md
@@ -91,6 +91,12 @@ flowchart TD
 - Degradation paths are not useful when the business action is all-or-nothing.
 - Backpressure logic that operators cannot understand becomes a new reliability risk.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Retry, circuit breaker, and bulkhead](retry-circuit-breaker-and-bulkhead.md)
+- [Multi-region active-passive vs active-active](multi-region-active-passive-vs-active-active.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/health-endpoint-monitoring

--- a/docs/patterns/resilience/multi-region-active-passive-vs-active-active.md
+++ b/docs/patterns/resilience/multi-region-active-passive-vs-active-active.md
@@ -105,6 +105,12 @@ flowchart TD
 - State consistency requirements are strict and cross-region write coordination is unacceptable.
 - The business does not value the additional cost and complexity enough to justify it.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Resilience and region strategy](../../platform/resilience-and-region-strategy.md)
+- [Retry, circuit breaker, and bulkhead](retry-circuit-breaker-and-bulkhead.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/networking/global-web-applications/overview

--- a/docs/patterns/resilience/retry-circuit-breaker-and-bulkhead.md
+++ b/docs/patterns/resilience/retry-circuit-breaker-and-bulkhead.md
@@ -100,6 +100,12 @@ flowchart TD
 - The operation is not idempotent and duplicates create business harm.
 - Failure originates from quota exhaustion or persistent misconfiguration.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Health endpoints, graceful degradation, and backpressure](health-endpoints-graceful-degradation-and-backpressure.md)
+- [WAF reliability pillar](../../waf/reliability.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/patterns/retry

--- a/docs/patterns/security/identity-first-and-secrets-flow.md
+++ b/docs/patterns/security/identity-first-and-secrets-flow.md
@@ -106,6 +106,12 @@ Examples where identity-first often works well include Azure SQL Database, Stora
 - Very small internal tools may start with Key Vault-backed secrets before full identity migration.
 - Some external services do not yet support Azure-native identity integration, so a residual secret path remains necessary.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Zero trust at workload level](zero-trust-at-workload-level.md)
+- [Identity and governance foundations](../../platform/identity-and-governance-foundations.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview

--- a/docs/patterns/security/zero-trust-at-workload-level.md
+++ b/docs/patterns/security/zero-trust-at-workload-level.md
@@ -96,6 +96,12 @@ flowchart TD
 - Not as a one-time product rollout without ownership for policy, exceptions, and monitoring.
 - Not as a full pattern if critical dependencies still depend on unbounded shared trust and no mitigation exists.
 
+## See Also
+
+- [Design patterns](../index.md)
+- [Identity-first and secrets flow](identity-first-and-secrets-flow.md)
+- [WAF security pillar](../../waf/security.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/security/fundamentals/zero-trust

--- a/docs/patterns/service-selection-patterns.md
+++ b/docs/patterns/service-selection-patterns.md
@@ -125,6 +125,12 @@ flowchart TD
 - [Observed] Team support capability, incident history, and operational complexity.
 - [Unknown] Assumptions not yet tested in a proof of concept.
 
+## See Also
+
+- [Design patterns](index.md)
+- [Architecture decision matrix](../reference/architecture-decision-matrix.md)
+- [Platform concepts](../platform/index.md)
+
 ## Microsoft Learn reference
 
 - https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/


### PR DESCRIPTION
## Summary
Adds the AGENTS.md-required `## See Also` tail section to all 21 `docs/patterns/` pages (data, decomposition, deployment, integration, networking, resilience, security subdirs plus `index.md` and `service-selection-patterns.md`).

## Details
Each page gains 3 curated intra-repo cross-links placed immediately before the closing `## Microsoft Learn reference(s)` block. Links connect each pattern to the patterns index, sibling patterns in the same category, and the relevant platform/WAF/operations/reference page.

## Verification
- `mkdocs build --strict` exit 0, no broken links
- `scripts/validate_content_sources.py` — all validations passed
- diff: +126 across 21 files, See Also only

Part of #12. Follows #59, #60, #61, #62, #63, #64.