### PR TITLE
docs(workload-guides): add See Also to workload guide pages (#12)

### DIFF
--- a/docs/workload-guides/event-driven-integration/baseline.md
+++ b/docs/workload-guides/event-driven-integration/baseline.md
@@ -95,6 +95,12 @@ This baseline is strongest when messaging, retries, and asynchronous completion 
 - Add more sophisticated orchestration only after proving simple queue or event patterns are insufficient. [Observed]
 - Keep broker choice aligned with delivery semantics rather than standardizing on one tool for every use case. [Validated]
 
+## See Also
+
+- [Event-driven integration overview](index.md)
+- [Messaging and consistency](messaging-and-consistency.md)
+- [Event-driven architecture](../../patterns/integration/event-driven-architecture.md)
+
 ## Microsoft Learn references
 
 - [Event-driven architecture style](https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven)

--- a/docs/workload-guides/event-driven-integration/cost-and-anti-patterns.md
+++ b/docs/workload-guides/event-driven-integration/cost-and-anti-patterns.md
@@ -93,6 +93,12 @@ FinOps reviews for event-driven systems should sample both message paths and dow
 
 That keeps hidden consumer cost visible. [Observed]
 
+## See Also
+
+- [Event-driven integration overview](index.md)
+- [Baseline architecture](baseline.md)
+- [Event-driven architecture](../../patterns/integration/event-driven-architecture.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework cost optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/workload-guides/event-driven-integration/index.md
+++ b/docs/workload-guides/event-driven-integration/index.md
@@ -88,6 +88,12 @@ Start with one well-owned event flow and prove replay, observability, and busine
 
 That sequencing lowers integration risk. [Inferred]
 
+## See Also
+
+- [Baseline architecture](baseline.md)
+- [Messaging and consistency](messaging-and-consistency.md)
+- [Event-driven architecture](../../patterns/integration/event-driven-architecture.md)
+
 ## Microsoft Learn references
 
 - [Event-driven architecture style](https://learn.microsoft.com/en-us/azure/architecture/guide/architecture-styles/event-driven)

--- a/docs/workload-guides/event-driven-integration/messaging-and-consistency.md
+++ b/docs/workload-guides/event-driven-integration/messaging-and-consistency.md
@@ -102,6 +102,12 @@ flowchart TD
 
 Messaging consistency is a system property built from broker semantics, consumer behavior, and business compensation rules together. [Validated]
 
+## See Also
+
+- [Event-driven integration overview](index.md)
+- [Operations and reliability](operations-and-reliability.md)
+- [Event-driven architecture](../../patterns/integration/event-driven-architecture.md)
+
 ## Microsoft Learn references
 
 - [Saga distributed transactions pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/saga)

--- a/docs/workload-guides/event-driven-integration/operations-and-reliability.md
+++ b/docs/workload-guides/event-driven-integration/operations-and-reliability.md
@@ -93,6 +93,12 @@ flowchart TD
 
 Reliable event-driven operations depend on visible backlog economics and disciplined exception handling, not just message acceptance success. [Validated]
 
+## See Also
+
+- [Event-driven integration overview](index.md)
+- [Cost and anti-patterns](cost-and-anti-patterns.md)
+- [Event-driven architecture](../../patterns/integration/event-driven-architecture.md)
+
 ## Microsoft Learn references
 
 - [Overview of Service Bus dead-letter queues](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues)

--- a/docs/workload-guides/index.md
+++ b/docs/workload-guides/index.md
@@ -94,6 +94,12 @@ Landing zones answer platform questions such as subscription hierarchy, guardrai
 - Treat benchmark numbers and cost examples as directional until validated in your tenant and region. [Inferred]
 - Use architecture decision records when deviating from a baseline for compliance, latency, or organizational reasons. [Validated]
 
+## See Also
+
+- [Public web API](public-web-api/index.md)
+- [Design patterns](../patterns/index.md)
+- [Architecture decision matrix](../reference/architecture-decision-matrix.md)
+
 ## Related Microsoft Learn references
 
 - [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/)

--- a/docs/workload-guides/landing-zone-shared-services/baseline.md
+++ b/docs/workload-guides/landing-zone-shared-services/baseline.md
@@ -95,6 +95,12 @@ The landing zone baseline is effective when it combines clear governance inherit
 
 Baseline landing zones should be opinionated enough to prevent drift but modular enough to add regions, business units, and shared capabilities without major rework. [Validated]
 
+## See Also
+
+- [Landing zone shared services overview](index.md)
+- [Governance and network topology](governance-and-network-topology.md)
+- [Landing zones basics](../../platform/landing-zones-basics.md)
+
 ## Microsoft Learn references
 
 - [Cloud Adoption Framework landing zones](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/)

--- a/docs/workload-guides/landing-zone-shared-services/cost-and-anti-patterns.md
+++ b/docs/workload-guides/landing-zone-shared-services/cost-and-anti-patterns.md
@@ -93,6 +93,12 @@ Cost discipline improves when shared services publish both consumption guidance 
 
 That supports better chargeback conversations. [Correlated]
 
+## See Also
+
+- [Landing zone shared services overview](index.md)
+- [Baseline architecture](baseline.md)
+- [Landing zones basics](../../platform/landing-zones-basics.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework cost optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/workload-guides/landing-zone-shared-services/governance-and-network-topology.md
+++ b/docs/workload-guides/landing-zone-shared-services/governance-and-network-topology.md
@@ -94,6 +94,12 @@ This reduces unmanaged drift. [Observed]
 
 It also clarifies shared accountability. [Correlated]
 
+## See Also
+
+- [Landing zone shared services overview](index.md)
+- [Platform operations](platform-operations.md)
+- [Landing zones basics](../../platform/landing-zones-basics.md)
+
 ## Microsoft Learn references
 
 - [Azure best practices and recommendations](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/)

--- a/docs/workload-guides/landing-zone-shared-services/index.md
+++ b/docs/workload-guides/landing-zone-shared-services/index.md
@@ -88,6 +88,12 @@ Landing zones create long-lived organizational constraints, so early design choi
 
 That improves long-term alignment. [Inferred]
 
+## See Also
+
+- [Baseline architecture](baseline.md)
+- [Governance and network topology](governance-and-network-topology.md)
+- [Landing zones basics](../../platform/landing-zones-basics.md)
+
 ## Microsoft Learn references
 
 - [Cloud Adoption Framework landing zones](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/)

--- a/docs/workload-guides/landing-zone-shared-services/platform-operations.md
+++ b/docs/workload-guides/landing-zone-shared-services/platform-operations.md
@@ -93,6 +93,12 @@ Platform operations should standardize visibility and control while preserving t
 
 The platform operations model is sustainable only when central teams can enable workload teams instead of becoming the only people who can interpret platform telemetry. [Validated]
 
+## See Also
+
+- [Landing zone shared services overview](index.md)
+- [Cost and anti-patterns](cost-and-anti-patterns.md)
+- [Landing zones basics](../../platform/landing-zones-basics.md)
+
 ## Microsoft Learn references
 
 - [Manage cloud adoption at scale](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/manage/)

--- a/docs/workload-guides/microservices-platform/baseline.md
+++ b/docs/workload-guides/microservices-platform/baseline.md
@@ -96,6 +96,12 @@ Shared databases often turn microservices into a distributed monolith. Database 
 
 This baseline works when the platform provides consistent paved roads while leaving service teams accountable for their own code, contracts, and data. [Validated]
 
+## See Also
+
+- [Microservices platform overview](index.md)
+- [Networking, identity, and service communication](networking-identity-and-service-communication.md)
+- [Modular monolith vs microservices](../../patterns/decomposition/modular-monolith-vs-microservices.md)
+
 ## Microsoft Learn references
 
 - [Architect microservices on Azure](https://learn.microsoft.com/en-us/azure/architecture/microservices/)

--- a/docs/workload-guides/microservices-platform/cost-and-anti-patterns.md
+++ b/docs/workload-guides/microservices-platform/cost-and-anti-patterns.md
@@ -93,6 +93,12 @@ Microservices are economically sound only when organizational speed, fault isola
 
 Review cost alongside architecture review outcomes so service sprawl is challenged with the same rigor as availability or security drift. [Validated]
 
+## See Also
+
+- [Microservices platform overview](index.md)
+- [Baseline architecture](baseline.md)
+- [Modular monolith vs microservices](../../patterns/decomposition/modular-monolith-vs-microservices.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework cost optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/workload-guides/microservices-platform/data-observability-and-reliability.md
+++ b/docs/workload-guides/microservices-platform/data-observability-and-reliability.md
@@ -98,6 +98,12 @@ flowchart TD
 
 Observability and data ownership are the control mechanisms that keep a microservices platform diagnosable and governable at scale. [Validated]
 
+## See Also
+
+- [Microservices platform overview](index.md)
+- [Cost and anti-patterns](cost-and-anti-patterns.md)
+- [Modular monolith vs microservices](../../patterns/decomposition/modular-monolith-vs-microservices.md)
+
 ## Microsoft Learn references
 
 - [Data considerations for microservices](https://learn.microsoft.com/en-us/azure/architecture/microservices/design/data-considerations)

--- a/docs/workload-guides/microservices-platform/index.md
+++ b/docs/workload-guides/microservices-platform/index.md
@@ -88,6 +88,12 @@ The first sign of a healthy microservices program is clearer team ownership, not
 
 Ownership should become easier to explain. [Observed]
 
+## See Also
+
+- [Baseline architecture](baseline.md)
+- [Networking, identity, and service communication](networking-identity-and-service-communication.md)
+- [Modular monolith vs microservices](../../patterns/decomposition/modular-monolith-vs-microservices.md)
+
 ## Microsoft Learn references
 
 - [Architect microservices on Azure](https://learn.microsoft.com/en-us/azure/architecture/microservices/)

--- a/docs/workload-guides/microservices-platform/networking-identity-and-service-communication.md
+++ b/docs/workload-guides/microservices-platform/networking-identity-and-service-communication.md
@@ -93,6 +93,12 @@ flowchart TD
 
 Communication architecture should minimize accidental coupling while keeping trust and policy controls understandable to service teams. [Validated]
 
+## See Also
+
+- [Microservices platform overview](index.md)
+- [Data, observability, and reliability](data-observability-and-reliability.md)
+- [Modular monolith vs microservices](../../patterns/decomposition/modular-monolith-vs-microservices.md)
+
 ## Microsoft Learn references
 
 - [Interservice communication in a microservices architecture](https://learn.microsoft.com/en-us/azure/architecture/microservices/design/interservice-communication)

--- a/docs/workload-guides/private-internal-app/baseline.md
+++ b/docs/workload-guides/private-internal-app/baseline.md
@@ -111,6 +111,12 @@ Private Endpoints let teams keep managed services while avoiding the false choic
 
 The baseline works best when the application team accepts that network, DNS, and identity are co-equal parts of the architecture. [Validated]
 
+## See Also
+
+- [Private internal app overview](index.md)
+- [Network and access](network-and-access.md)
+- [Private connectivity patterns](../../patterns/networking/private-connectivity-patterns.md)
+
 ## Microsoft Learn references
 
 - [Baseline highly available zone-redundant web application](https://learn.microsoft.com/en-us/azure/architecture/web-apps/app-service/architectures/baseline-zone-redundant)

--- a/docs/workload-guides/private-internal-app/cost-and-anti-patterns.md
+++ b/docs/workload-guides/private-internal-app/cost-and-anti-patterns.md
@@ -99,6 +99,12 @@ The right private architecture cost model includes platform complexity, support 
 
 Private architecture remains economically sound when each additional network control can be traced to a real security, compliance, or continuity outcome. [Observed]
 
+## See Also
+
+- [Private internal app overview](index.md)
+- [Baseline architecture](baseline.md)
+- [Private connectivity patterns](../../patterns/networking/private-connectivity-patterns.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework cost optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/workload-guides/private-internal-app/data-and-integration.md
+++ b/docs/workload-guides/private-internal-app/data-and-integration.md
@@ -99,6 +99,12 @@ flowchart TD
 
 Internal application integration stays maintainable when data ownership, message ownership, and identity ownership are all explicit. [Validated]
 
+## See Also
+
+- [Private internal app overview](index.md)
+- [Operations and reliability](operations-and-reliability.md)
+- [Private connectivity patterns](../../patterns/networking/private-connectivity-patterns.md)
+
 ## Microsoft Learn references
 
 - [Service Bus messaging overview](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview)

--- a/docs/workload-guides/private-internal-app/index.md
+++ b/docs/workload-guides/private-internal-app/index.md
@@ -92,6 +92,12 @@ Choose this family when private reachability and controlled enterprise access ar
 
 Internal application baselines are most effective when application, network, and identity teams agree on one service ownership model before implementation begins. [Correlated]
 
+## See Also
+
+- [Baseline architecture](baseline.md)
+- [Network and access](network-and-access.md)
+- [Private connectivity patterns](../../patterns/networking/private-connectivity-patterns.md)
+
 ## Microsoft Learn references
 
 - [Private Endpoint overview](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview)

--- a/docs/workload-guides/private-internal-app/network-and-access.md
+++ b/docs/workload-guides/private-internal-app/network-and-access.md
@@ -102,6 +102,12 @@ Do not collapse user and operator paths into the same endpoint. Separate adminis
 
 Strong private access architecture depends on predictable name resolution and clearly governed network paths more than on any single Azure service choice. [Validated]
 
+## See Also
+
+- [Private internal app overview](index.md)
+- [Data and integration](data-and-integration.md)
+- [Private connectivity patterns](../../patterns/networking/private-connectivity-patterns.md)
+
 ## Microsoft Learn references
 
 - [Private Endpoint overview](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview)

--- a/docs/workload-guides/private-internal-app/operations-and-reliability.md
+++ b/docs/workload-guides/private-internal-app/operations-and-reliability.md
@@ -95,6 +95,12 @@ flowchart TD
 
 Reliable internal applications require an operating model that treats connectivity and name resolution as part of production health, not background infrastructure. [Validated]
 
+## See Also
+
+- [Private internal app overview](index.md)
+- [Cost and anti-patterns](cost-and-anti-patterns.md)
+- [Private connectivity patterns](../../patterns/networking/private-connectivity-patterns.md)
+
 ## Microsoft Learn references
 
 - [Azure Monitor overview](https://learn.microsoft.com/en-us/azure/azure-monitor/overview)

--- a/docs/workload-guides/public-web-api/baseline.md
+++ b/docs/workload-guides/public-web-api/baseline.md
@@ -92,6 +92,12 @@ Most public web applications are operational systems, not analytical platforms. 
 - Cosmos DB cost can rise quickly when partitioning and RU allocation are chosen without measured access patterns. [Correlated]
 - Multi-region active-active adds operational complexity that many teams underestimate in deployment, cache invalidation, and data conflict handling. [Correlated]
 
+## See Also
+
+- [Public web API overview](index.md)
+- [Network edge and identity](network-edge-and-identity.md)
+- [Synchronous vs asynchronous](../../patterns/integration/synchronous-vs-asynchronous.md)
+
 ## Evidence and references
 
 - [Baseline highly available zone-redundant web application](https://learn.microsoft.com/en-us/azure/architecture/web-apps/app-service/architectures/baseline-zone-redundant)

--- a/docs/workload-guides/public-web-api/cost-and-anti-patterns.md
+++ b/docs/workload-guides/public-web-api/cost-and-anti-patterns.md
@@ -97,6 +97,12 @@ Public web cost discipline comes from linking each major spending area to a user
 
 The best public web cost optimizations usually remove unused complexity before they reduce runtime scale. [Observed]
 
+## See Also
+
+- [Public web API overview](index.md)
+- [Baseline architecture](baseline.md)
+- [Synchronous vs asynchronous](../../patterns/integration/synchronous-vs-asynchronous.md)
+
 ## Microsoft Learn references
 
 - [Azure Well-Architected Framework cost optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/workload-guides/public-web-api/data-and-state.md
+++ b/docs/workload-guides/public-web-api/data-and-state.md
@@ -97,6 +97,12 @@ Public APIs often mix strongly consistent transactional writes with eventually c
 
 Good web workload state design keeps compute disposable and makes durable state explicit, minimal, and measurable. [Validated]
 
+## See Also
+
+- [Public web API overview](index.md)
+- [Operations and reliability](operations-and-reliability.md)
+- [Synchronous vs asynchronous](../../patterns/integration/synchronous-vs-asynchronous.md)
+
 ## Microsoft Learn references
 
 - [Choose a data store for an application](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/data-store-overview)

--- a/docs/workload-guides/public-web-api/index.md
+++ b/docs/workload-guides/public-web-api/index.md
@@ -102,6 +102,12 @@ flowchart TD
 
 This family fits when public ingress, managed web operations, and predictable API delivery are the primary architecture drivers. [Validated]
 
+## See Also
+
+- [Baseline architecture](baseline.md)
+- [Network edge and identity](network-edge-and-identity.md)
+- [Synchronous vs asynchronous](../../patterns/integration/synchronous-vs-asynchronous.md)
+
 ## Microsoft Learn references
 
 - [Baseline highly available zone-redundant web application](https://learn.microsoft.com/en-us/azure/architecture/web-apps/app-service/architectures/baseline-zone-redundant)

--- a/docs/workload-guides/public-web-api/network-edge-and-identity.md
+++ b/docs/workload-guides/public-web-api/network-edge-and-identity.md
@@ -109,6 +109,12 @@ sequenceDiagram
 
 Public edge and identity design should concentrate control at the boundary while keeping application code focused on business behavior. [Validated]
 
+## See Also
+
+- [Public web API overview](index.md)
+- [Data and state](data-and-state.md)
+- [Synchronous vs asynchronous](../../patterns/integration/synchronous-vs-asynchronous.md)
+
 ## Microsoft Learn references
 
 - [Azure Front Door overview](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview)

--- a/docs/workload-guides/public-web-api/operations-and-reliability.md
+++ b/docs/workload-guides/public-web-api/operations-and-reliability.md
@@ -101,6 +101,12 @@ flowchart TD
 
 Reliable public workloads combine edge health, safe deployment mechanics, and dependency-aware continuity planning in one operating model. [Validated]
 
+## See Also
+
+- [Public web API overview](index.md)
+- [Cost and anti-patterns](cost-and-anti-patterns.md)
+- [Synchronous vs asynchronous](../../patterns/integration/synchronous-vs-asynchronous.md)
+
 ## Microsoft Learn references
 
 - [Azure App Service reliability](https://learn.microsoft.com/en-us/azure/reliability/reliability-app-service)

--- a/docs/workload-guides/serverless-processing/baseline.md
+++ b/docs/workload-guides/serverless-processing/baseline.md
@@ -97,6 +97,12 @@ Teams can start with simple handlers and add Durable Functions, richer messaging
 - Durable Functions can simplify coordination while increasing storage, replay, and debugging complexity. [Correlated]
 - Trigger concurrency can overwhelm downstream systems if backpressure is not deliberate. [Validated]
 
+## See Also
+
+- [Serverless processing overview](index.md)
+- [Triggers, state, and storage](triggers-state-and-storage.md)
+- [Queue-based load leveling and competing consumers](../../patterns/integration/queue-based-load-leveling-and-competing-consumers.md)
+
 ## Evidence and references
 
 - [Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)

--- a/docs/workload-guides/serverless-processing/cost-and-anti-patterns.md
+++ b/docs/workload-guides/serverless-processing/cost-and-anti-patterns.md
@@ -96,6 +96,12 @@ flowchart TD
 
 Serverless cost discipline comes from aligning plan choice, retry behavior, and state design with real workload shape rather than assuming pay-per-use will optimize itself. [Validated]
 
+## See Also
+
+- [Serverless processing overview](index.md)
+- [Baseline architecture](baseline.md)
+- [Queue-based load leveling and competing consumers](../../patterns/integration/queue-based-load-leveling-and-competing-consumers.md)
+
 ## Microsoft Learn references
 
 - [Azure Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/workload-guides/serverless-processing/index.md
+++ b/docs/workload-guides/serverless-processing/index.md
@@ -107,6 +107,12 @@ flowchart TD
 
 This family fits when event-driven execution, managed scaling, and explicit workflow state matter more than owning long-lived servers or a permanent application tier. [Validated]
 
+## See Also
+
+- [Baseline architecture](baseline.md)
+- [Triggers, state, and storage](triggers-state-and-storage.md)
+- [Queue-based load leveling and competing consumers](../../patterns/integration/queue-based-load-leveling-and-competing-consumers.md)
+
 ## Microsoft Learn references
 
 - [Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)

--- a/docs/workload-guides/serverless-processing/operations-and-reliability.md
+++ b/docs/workload-guides/serverless-processing/operations-and-reliability.md
@@ -100,6 +100,12 @@ flowchart TD
 
 Serverless reliability comes from disciplined backlog management, idempotent execution, and dependency-aware recovery, not from assuming the platform will hide every failure mode. [Validated]
 
+## See Also
+
+- [Serverless processing overview](index.md)
+- [Cost and anti-patterns](cost-and-anti-patterns.md)
+- [Queue-based load leveling and competing consumers](../../patterns/integration/queue-based-load-leveling-and-competing-consumers.md)
+
 ## Microsoft Learn references
 
 - [Azure Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/workload-guides/serverless-processing/triggers-state-and-storage.md
+++ b/docs/workload-guides/serverless-processing/triggers-state-and-storage.md
@@ -101,6 +101,12 @@ flowchart TD
 
 Good serverless designs separate trigger semantics, orchestration mechanics, and durable business data so each can scale and recover on its own terms. [Validated]
 
+## See Also
+
+- [Serverless processing overview](index.md)
+- [Operations and reliability](operations-and-reliability.md)
+- [Queue-based load leveling and competing consumers](../../patterns/integration/queue-based-load-leveling-and-competing-consumers.md)
+
 ## Microsoft Learn references
 
 - [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)


### PR DESCRIPTION
## Summary
Adds the AGENTS.md-required `## See Also` tail section to all 33 `docs/workload-guides/` pages across the six workload families (public-web-api, private-internal-app, event-driven-integration, microservices-platform, serverless-processing, landing-zone-shared-services) plus the top `index.md`.

## Details
Each sub-page gains 3 curated intra-repo cross-links: its workload overview, a sibling sub-page in the same workload, and a relevant pattern/platform page. Each workload `index.md` links two of its sub-pages plus a cross-section page. Placement is immediately before the external-references heading, which varies by page:
- most pages: `## Microsoft Learn references`
- `public-web-api/baseline.md`, `serverless-processing/baseline.md`: `## Evidence and references`
- top `index.md`: `## Related Microsoft Learn references`

## Verification
- `mkdocs build --strict` exit 0, no broken links
- `scripts/validate_content_sources.py` — all validations passed
- diff: +198 across 33 files, See Also only

Part of #12. Completes the See Also rollout begun in #59, #60, #61, #62, #63, #64, #65.