### PR TITLE
docs(about): add See Also to about page (#12)

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -94,6 +94,12 @@ That implies:
 - pages should be scoped tightly enough to stay current
 - build and link validation should be part of contribution hygiene
 
+## See Also
+
+- [Start here: overview](start-here/overview.md)
+- [Platform concepts](platform/index.md)
+- [Design labs](design-labs/index.md)
+
 ## Microsoft Learn anchors
 
 - [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/)


### PR DESCRIPTION
## Summary
Adds the AGENTS.md-required `## See Also` tail section to `docs/about.md` — the last remaining page missing it after PRs #59–66.

## Details
Adds 3 curated intra-repo links (start-here overview, platform concepts, design labs) placed immediately before `## Microsoft Learn anchors`, keeping the closing `## Disclaimer` / `## Takeaway` sections intact.

Also confirms two audit follow-ups need no change:
- `contributing/language-guide-baseline.md` — the "empty See Also" occurrences flagged by the audit are template examples inside fenced code blocks; the page's own See Also is populated with cross-repo links.
- The audit's "generic landing URL" notes were ancillary observations on See-Also-missing rows, all now addressed. Upgrading generic→specific Source URLs is a separate editorial pass (landing URLs remain valid MSLearn sources).

## Verification
- `mkdocs build --strict` exit 0, no broken links
- `scripts/validate_content_sources.py` — passed
- diff: +6, See Also only

Part of #12. Completes the See Also rollout (#59–#66).