### PR TITLE
feat: add 18 foundation Bicep capability modules (#14)

### DIFF
--- a/infra/bicep/modules/data/sql-database.bicep
+++ b/infra/bicep/modules/data/sql-database.bicep
@@ -1,0 +1,44 @@
+@description('Name of the parent SQL logical server.')
+param sqlServerName string
+
+@description('Name of the database.')
+param name string
+
+@description('Azure region for the database.')
+param location string = resourceGroup().location
+
+@description('SKU name for the database, for example S0.')
+param skuName string = 'S0'
+
+@description('SKU tier for the database.')
+param skuTier string = 'Standard'
+
+@description('Maximum database size in bytes.')
+param maxSizeBytes int = 268435456000
+
+@description('Resource tags.')
+param tags object = {}
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+  name: sqlServerName
+}
+
+resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuTier
+  }
+  properties: {
+    maxSizeBytes: maxSizeBytes
+  }
+}
+
+@description('Resource ID of the database.')
+output id string = database.id
+
+@description('Name of the database.')
+output name string = database.name

--- a/infra/bicep/modules/data/sql-database.bicep
+++ b/infra/bicep/modules/data/sql-database.bicep
@@ -19,11 +19,11 @@ param maxSizeBytes int = 268435456000
 @description('Resource tags.')
 param tags object = {}
 
-resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' existing = {
   name: sqlServerName
 }
 
-resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+resource database 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sqlServer
   name: name
   location: location

--- a/infra/bicep/modules/data/sql-failover-group.bicep
+++ b/infra/bicep/modules/data/sql-failover-group.bicep
@@ -13,11 +13,11 @@ param databaseIds array
 @description('Grace period in minutes before automatic failover with data loss.')
 param gracePeriodMinutes int = 60
 
-resource primaryServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource primaryServer 'Microsoft.Sql/servers@2021-11-01' existing = {
   name: primaryServerName
 }
 
-resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2023-08-01-preview' = {
+resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2021-11-01' = {
   parent: primaryServer
   name: name
   properties: {

--- a/infra/bicep/modules/data/sql-failover-group.bicep
+++ b/infra/bicep/modules/data/sql-failover-group.bicep
@@ -1,0 +1,41 @@
+@description('Name of the primary SQL logical server.')
+param primaryServerName string
+
+@description('Name of the failover group.')
+param name string
+
+@description('Resource ID of the partner (secondary) SQL logical server.')
+param partnerServerId string
+
+@description('Resource IDs of the databases to include in the failover group.')
+param databaseIds array
+
+@description('Grace period in minutes before automatic failover with data loss.')
+param gracePeriodMinutes int = 60
+
+resource primaryServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+  name: primaryServerName
+}
+
+resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2023-08-01-preview' = {
+  parent: primaryServer
+  name: name
+  properties: {
+    readWriteEndpoint: {
+      failoverPolicy: 'Automatic'
+      failoverWithDataLossGracePeriodMinutes: gracePeriodMinutes
+    }
+    partnerServers: [
+      {
+        id: partnerServerId
+      }
+    ]
+    databases: databaseIds
+  }
+}
+
+@description('Resource ID of the failover group.')
+output id string = failoverGroup.id
+
+@description('Name of the failover group.')
+output name string = failoverGroup.name

--- a/infra/bicep/modules/data/sql-logical-server.bicep
+++ b/infra/bicep/modules/data/sql-logical-server.bicep
@@ -21,7 +21,7 @@ param publicNetworkAccess string = 'Disabled'
 @description('Resource tags.')
 param tags object = {}
 
-resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   name: name
   location: location
   tags: tags

--- a/infra/bicep/modules/data/sql-logical-server.bicep
+++ b/infra/bicep/modules/data/sql-logical-server.bicep
@@ -1,0 +1,44 @@
+@description('Name of the SQL logical server.')
+param name string
+
+@description('Azure region for the server.')
+param location string = resourceGroup().location
+
+@description('Administrator login name.')
+param administratorLogin string
+
+@description('Administrator login password.')
+@secure()
+param administratorLoginPassword string
+
+@description('Allow public network access to the server.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Disabled'
+
+@description('Resource tags.')
+param tags object = {}
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: publicNetworkAccess
+  }
+}
+
+@description('Resource ID of the SQL logical server.')
+output id string = sqlServer.id
+
+@description('Name of the SQL logical server.')
+output name string = sqlServer.name
+
+@description('Fully qualified domain name of the server.')
+output fullyQualifiedDomainName string = sqlServer.properties.fullyQualifiedDomainName

--- a/infra/bicep/modules/foundation/action-group.bicep
+++ b/infra/bicep/modules/foundation/action-group.bicep
@@ -1,0 +1,36 @@
+@description('Name of the action group.')
+param name string
+
+@description('Short name (max 12 characters) shown in notifications.')
+@maxLength(12)
+param groupShortName string
+
+@description('Email receivers. Each item requires a name and emailAddress.')
+param emailReceivers array = []
+
+@description('Enable the action group.')
+param enabled bool = true
+
+@description('Resource tags.')
+param tags object = {}
+
+resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: name
+  location: 'Global'
+  tags: tags
+  properties: {
+    groupShortName: groupShortName
+    enabled: enabled
+    emailReceivers: [for receiver in emailReceivers: {
+      name: receiver.name
+      emailAddress: receiver.emailAddress
+      useCommonAlertSchema: true
+    }]
+  }
+}
+
+@description('Resource ID of the action group.')
+output id string = actionGroup.id
+
+@description('Name of the action group.')
+output name string = actionGroup.name

--- a/infra/bicep/modules/foundation/application-insights.bicep
+++ b/infra/bicep/modules/foundation/application-insights.bicep
@@ -1,0 +1,38 @@
+@description('Name of the Application Insights component.')
+param name string
+
+@description('Azure region for the component.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the Log Analytics workspace backing this component.')
+param workspaceResourceId string
+
+@description('Application type.')
+param applicationType string = 'web'
+
+@description('Resource tags.')
+param tags object = {}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: name
+  location: location
+  tags: tags
+  kind: applicationType
+  properties: {
+    Application_Type: applicationType
+    WorkspaceResourceId: workspaceResourceId
+    IngestionMode: 'LogAnalytics'
+  }
+}
+
+@description('Resource ID of the Application Insights component.')
+output id string = appInsights.id
+
+@description('Name of the Application Insights component.')
+output name string = appInsights.name
+
+@description('Instrumentation key for the component.')
+output instrumentationKey string = appInsights.properties.InstrumentationKey
+
+@description('Connection string for the component.')
+output connectionString string = appInsights.properties.ConnectionString

--- a/infra/bicep/modules/foundation/autoscale-settings.bicep
+++ b/infra/bicep/modules/foundation/autoscale-settings.bicep
@@ -1,0 +1,98 @@
+@description('Name of the autoscale setting.')
+param name string
+
+@description('Azure region for the autoscale setting.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the target resource to scale, for example an App Service plan.')
+param targetResourceId string
+
+@description('Minimum instance count.')
+param minimumCapacity int = 1
+
+@description('Maximum instance count.')
+param maximumCapacity int = 10
+
+@description('Default instance count when no rule applies.')
+param defaultCapacity int = 1
+
+@description('Metric evaluated for scaling decisions.')
+param metricName string = 'CpuPercentage'
+
+@description('Metric namespace of the target resource.')
+param metricNamespace string = 'Microsoft.Web/serverfarms'
+
+@description('Scale-out threshold. Exceeding this adds an instance.')
+param scaleOutThreshold int = 70
+
+@description('Scale-in threshold. Falling below this removes an instance.')
+param scaleInThreshold int = 30
+
+@description('Resource tags.')
+param tags object = {}
+
+resource autoscale 'Microsoft.Insights/autoscaleSettings@2022-10-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    enabled: true
+    targetResourceUri: targetResourceId
+    profiles: [
+      {
+        name: 'Default profile'
+        capacity: {
+          minimum: string(minimumCapacity)
+          maximum: string(maximumCapacity)
+          default: string(defaultCapacity)
+        }
+        rules: [
+          {
+            metricTrigger: {
+              metricName: metricName
+              metricNamespace: metricNamespace
+              metricResourceUri: targetResourceId
+              timeGrain: 'PT1M'
+              statistic: 'Average'
+              timeWindow: 'PT5M'
+              timeAggregation: 'Average'
+              operator: 'GreaterThan'
+              threshold: scaleOutThreshold
+            }
+            scaleAction: {
+              direction: 'Increase'
+              type: 'ChangeCount'
+              value: '1'
+              cooldown: 'PT5M'
+            }
+          }
+          {
+            metricTrigger: {
+              metricName: metricName
+              metricNamespace: metricNamespace
+              metricResourceUri: targetResourceId
+              timeGrain: 'PT1M'
+              statistic: 'Average'
+              timeWindow: 'PT5M'
+              timeAggregation: 'Average'
+              operator: 'LessThan'
+              threshold: scaleInThreshold
+            }
+            scaleAction: {
+              direction: 'Decrease'
+              type: 'ChangeCount'
+              value: '1'
+              cooldown: 'PT5M'
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the autoscale setting.')
+output id string = autoscale.id
+
+@description('Name of the autoscale setting.')
+output name string = autoscale.name

--- a/infra/bicep/modules/foundation/key-vault.bicep
+++ b/infra/bicep/modules/foundation/key-vault.bicep
@@ -16,6 +16,13 @@ param softDeleteRetentionInDays int = 90
 @description('Enable purge protection to prevent permanent deletion during the retention period.')
 param enablePurgeProtection bool = true
 
+@description('Allow public network access to the vault. Defaults to Disabled for a secure baseline.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Disabled'
+
 @description('Resource tags.')
 param tags object = {}
 
@@ -33,6 +40,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enableSoftDelete: true
     softDeleteRetentionInDays: softDeleteRetentionInDays
     enablePurgeProtection: enablePurgeProtection ? true : null
+    publicNetworkAccess: publicNetworkAccess
   }
 }
 

--- a/infra/bicep/modules/foundation/key-vault.bicep
+++ b/infra/bicep/modules/foundation/key-vault.bicep
@@ -1,0 +1,46 @@
+@description('Name of the key vault.')
+param name string
+
+@description('Azure region for the key vault.')
+param location string = resourceGroup().location
+
+@description('Pricing tier for the key vault.')
+param sku string = 'standard'
+
+@description('Enable Azure RBAC for data-plane authorization instead of access policies.')
+param enableRbacAuthorization bool = true
+
+@description('Number of days to retain soft-deleted vaults and secrets.')
+param softDeleteRetentionInDays int = 90
+
+@description('Enable purge protection to prevent permanent deletion during the retention period.')
+param enablePurgeProtection bool = true
+
+@description('Resource tags.')
+param tags object = {}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      family: 'A'
+      name: sku
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: enableRbacAuthorization
+    enableSoftDelete: true
+    softDeleteRetentionInDays: softDeleteRetentionInDays
+    enablePurgeProtection: enablePurgeProtection ? true : null
+  }
+}
+
+@description('Resource ID of the key vault.')
+output id string = keyVault.id
+
+@description('Name of the key vault.')
+output name string = keyVault.name
+
+@description('URI of the key vault for data-plane access.')
+output vaultUri string = keyVault.properties.vaultUri

--- a/infra/bicep/modules/foundation/log-analytics-workspace.bicep
+++ b/infra/bicep/modules/foundation/log-analytics-workspace.bicep
@@ -1,0 +1,38 @@
+@description('Name of the Log Analytics workspace.')
+param name string
+
+@description('Azure region for the workspace.')
+param location string = resourceGroup().location
+
+@description('Pricing tier for the workspace.')
+param sku string = 'PerGB2018'
+
+@description('Data retention in days.')
+param retentionInDays int = 30
+
+@description('Resource tags.')
+param tags object = {}
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: sku
+    }
+    retentionInDays: retentionInDays
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+  }
+}
+
+@description('Resource ID of the Log Analytics workspace.')
+output id string = workspace.id
+
+@description('Name of the Log Analytics workspace.')
+output name string = workspace.name
+
+@description('Customer (workspace) ID used by data sources.')
+output customerId string = workspace.properties.customerId

--- a/infra/bicep/modules/foundation/metric-alerts.bicep
+++ b/infra/bicep/modules/foundation/metric-alerts.bicep
@@ -1,0 +1,99 @@
+@description('Name of the metric alert rule.')
+param name string
+
+@description('Description of what the alert monitors.')
+param alertDescription string = ''
+
+@description('Resource ID of the target resource being monitored.')
+param targetResourceId string
+
+@description('Metric namespace of the target resource, for example Microsoft.Web/sites.')
+param metricNamespace string
+
+@description('Name of the metric to evaluate.')
+param metricName string
+
+@description('Comparison operator for the threshold.')
+@allowed([
+  'GreaterThan'
+  'GreaterThanOrEqual'
+  'LessThan'
+  'LessThanOrEqual'
+])
+param operator string = 'GreaterThan'
+
+@description('Aggregation applied to the metric before comparison.')
+@allowed([
+  'Average'
+  'Minimum'
+  'Maximum'
+  'Total'
+  'Count'
+])
+param timeAggregation string = 'Average'
+
+@description('Threshold value that triggers the alert.')
+param threshold int
+
+@description('Alert severity, 0 (critical) to 4 (verbose).')
+@allowed([
+  0
+  1
+  2
+  3
+  4
+])
+param severity int = 3
+
+@description('How often the rule evaluates, ISO 8601 duration.')
+param evaluationFrequency string = 'PT5M'
+
+@description('Time window over which the metric is aggregated, ISO 8601 duration.')
+param windowSize string = 'PT15M'
+
+@description('Resource ID of the action group to notify. Empty disables notification.')
+param actionGroupId string = ''
+
+@description('Resource tags.')
+param tags object = {}
+
+resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: name
+  location: 'global'
+  tags: tags
+  properties: {
+    description: alertDescription
+    severity: severity
+    enabled: true
+    scopes: [
+      targetResourceId
+    ]
+    evaluationFrequency: evaluationFrequency
+    windowSize: windowSize
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: metricNamespace
+          metricName: metricName
+          operator: operator
+          timeAggregation: timeAggregation
+          threshold: threshold
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: empty(actionGroupId) ? [] : [
+      {
+        actionGroupId: actionGroupId
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the metric alert.')
+output id string = metricAlert.id
+
+@description('Name of the metric alert.')
+output name string = metricAlert.name

--- a/infra/bicep/modules/foundation/role-assignment.bicep
+++ b/infra/bicep/modules/foundation/role-assignment.bicep
@@ -1,0 +1,30 @@
+@description('Principal (object) ID that receives the role assignment.')
+param principalId string
+
+@description('Resource ID of the role definition to assign.')
+param roleDefinitionId string
+
+@description('Type of principal receiving the assignment.')
+@allowed([
+  'User'
+  'Group'
+  'ServicePrincipal'
+  'ForeignGroup'
+  'Device'
+])
+param principalType string = 'ServicePrincipal'
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, principalId, roleDefinitionId)
+  properties: {
+    principalId: principalId
+    roleDefinitionId: roleDefinitionId
+    principalType: principalType
+  }
+}
+
+@description('Resource ID of the role assignment.')
+output id string = roleAssignment.id
+
+@description('Name (GUID) of the role assignment.')
+output name string = roleAssignment.name

--- a/infra/bicep/modules/network/private-dns-zone.bicep
+++ b/infra/bicep/modules/network/private-dns-zone.bicep
@@ -1,0 +1,32 @@
+@description('Name of the private DNS zone, for example privatelink.database.windows.net.')
+param name string
+
+@description('Virtual networks to link to this zone. Each item requires name and virtualNetworkId.')
+param virtualNetworkLinks array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: name
+  location: 'global'
+  tags: tags
+}
+
+resource links 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = [for link in virtualNetworkLinks: {
+  parent: privateDnsZone
+  name: link.name
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: link.virtualNetworkId
+    }
+  }
+}]
+
+@description('Resource ID of the private DNS zone.')
+output id string = privateDnsZone.id
+
+@description('Name of the private DNS zone.')
+output name string = privateDnsZone.name

--- a/infra/bicep/modules/network/private-endpoint-sql.bicep
+++ b/infra/bicep/modules/network/private-endpoint-sql.bicep
@@ -1,0 +1,60 @@
+@description('Name of the private endpoint.')
+param name string
+
+@description('Azure region for the private endpoint.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the subnet hosting the private endpoint.')
+param subnetId string
+
+@description('Resource ID of the target SQL logical server.')
+param sqlServerId string
+
+@description('Resource ID of the private DNS zone for SQL. Empty skips DNS integration.')
+param privateDnsZoneId string = ''
+
+@description('Resource tags.')
+param tags object = {}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${name}-connection'
+        properties: {
+          privateLinkServiceId: sqlServerId
+          groupIds: [
+            'sqlServer'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!empty(privateDnsZoneId)) {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'sql'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the private endpoint.')
+output id string = privateEndpoint.id
+
+@description('Name of the private endpoint.')
+output name string = privateEndpoint.name

--- a/infra/bicep/modules/network/private-endpoint-webapp.bicep
+++ b/infra/bicep/modules/network/private-endpoint-webapp.bicep
@@ -1,0 +1,60 @@
+@description('Name of the private endpoint.')
+param name string
+
+@description('Azure region for the private endpoint.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the subnet hosting the private endpoint.')
+param subnetId string
+
+@description('Resource ID of the target web app.')
+param webAppId string
+
+@description('Resource ID of the private DNS zone for the web app. Empty skips DNS integration.')
+param privateDnsZoneId string = ''
+
+@description('Resource tags.')
+param tags object = {}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${name}-connection'
+        properties: {
+          privateLinkServiceId: webAppId
+          groupIds: [
+            'sites'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!empty(privateDnsZoneId)) {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'sites'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the private endpoint.')
+output id string = privateEndpoint.id
+
+@description('Name of the private endpoint.')
+output name string = privateEndpoint.name

--- a/infra/bicep/modules/network/virtual-network.bicep
+++ b/infra/bicep/modules/network/virtual-network.bicep
@@ -1,0 +1,43 @@
+@description('Name of the virtual network.')
+param name string
+
+@description('Azure region for the virtual network.')
+param location string = resourceGroup().location
+
+@description('Address prefixes for the virtual network.')
+param addressPrefixes array = [
+  '10.0.0.0/16'
+]
+
+@description('Subnets to create. Each item requires name and addressPrefix.')
+param subnets array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: addressPrefixes
+    }
+    subnets: [for subnet in subnets: {
+      name: subnet.name
+      properties: {
+        addressPrefix: subnet.addressPrefix
+        privateEndpointNetworkPolicies: subnet.?privateEndpointNetworkPolicies ?? 'Disabled'
+      }
+    }]
+  }
+}
+
+@description('Resource ID of the virtual network.')
+output id string = virtualNetwork.id
+
+@description('Name of the virtual network.')
+output name string = virtualNetwork.name
+
+@description('Resource IDs of the created subnets.')
+output subnetIds array = [for (subnet, i) in subnets: virtualNetwork.properties.subnets[i].id]

--- a/infra/bicep/modules/web/app-service-plan.bicep
+++ b/infra/bicep/modules/web/app-service-plan.bicep
@@ -1,0 +1,41 @@
+@description('Name of the App Service plan.')
+param name string
+
+@description('Azure region for the plan.')
+param location string = resourceGroup().location
+
+@description('SKU name for the plan, for example P1v3.')
+param skuName string = 'P1v3'
+
+@description('SKU tier for the plan.')
+param skuTier string = 'PremiumV3'
+
+@description('Number of worker instances.')
+param capacity int = 1
+
+@description('Host the plan on Linux.')
+param linux bool = true
+
+@description('Resource tags.')
+param tags object = {}
+
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuTier
+    capacity: capacity
+  }
+  kind: linux ? 'linux' : 'app'
+  properties: {
+    reserved: linux
+  }
+}
+
+@description('Resource ID of the App Service plan.')
+output id string = plan.id
+
+@description('Name of the App Service plan.')
+output name string = plan.name

--- a/infra/bicep/modules/web/front-door-standard.bicep
+++ b/infra/bicep/modules/web/front-door-standard.bicep
@@ -1,0 +1,79 @@
+@description('Name of the Front Door profile.')
+param name string
+
+@description('Name of the Front Door endpoint.')
+param endpointName string = name
+
+@description('SKU for the Front Door profile.')
+@allowed([
+  'Standard_AzureFrontDoor'
+  'Premium_AzureFrontDoor'
+])
+param skuName string = 'Standard_AzureFrontDoor'
+
+@description('Name of the WAF policy.')
+param wafPolicyName string = '${replace(name, '-', '')}waf'
+
+@description('WAF policy mode.')
+@allowed([
+  'Detection'
+  'Prevention'
+])
+param wafMode string = 'Prevention'
+
+@description('Resource tags.')
+param tags object = {}
+
+resource profile 'Microsoft.Cdn/profiles@2023-05-01' = {
+  name: name
+  location: 'Global'
+  tags: tags
+  sku: {
+    name: skuName
+  }
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/afdEndpoints@2023-05-01' = {
+  parent: profile
+  name: endpointName
+  location: 'Global'
+  properties: {
+    enabledState: 'Enabled'
+  }
+}
+
+resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2022-05-01' = {
+  name: wafPolicyName
+  location: 'Global'
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  properties: {
+    policySettings: {
+      enabledState: 'Enabled'
+      mode: wafMode
+    }
+    managedRules: {
+      managedRuleSets: [
+        {
+          ruleSetType: 'Microsoft_DefaultRuleSet'
+          ruleSetVersion: '2.1'
+          ruleSetAction: 'Block'
+        }
+      ]
+    }
+  }
+}
+
+@description('Resource ID of the Front Door profile.')
+output profileId string = profile.id
+
+@description('Resource ID of the Front Door endpoint.')
+output endpointId string = endpoint.id
+
+@description('Host name of the Front Door endpoint.')
+output endpointHostName string = endpoint.properties.hostName
+
+@description('Resource ID of the WAF policy.')
+output wafPolicyId string = wafPolicy.id

--- a/infra/bicep/modules/web/front-door-standard.bicep
+++ b/infra/bicep/modules/web/front-door-standard.bicep
@@ -66,6 +66,31 @@ resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@20
   }
 }
 
+resource securityPolicy 'Microsoft.Cdn/profiles/securityPolicies@2023-05-01' = {
+  parent: profile
+  name: '${name}-security-policy'
+  properties: {
+    parameters: {
+      type: 'WebApplicationFirewall'
+      wafPolicy: {
+        id: wafPolicy.id
+      }
+      associations: [
+        {
+          domains: [
+            {
+              id: endpoint.id
+            }
+          ]
+          patternsToMatch: [
+            '/*'
+          ]
+        }
+      ]
+    }
+  }
+}
+
 @description('Resource ID of the Front Door profile.')
 output profileId string = profile.id
 

--- a/infra/bicep/modules/web/web-app-slot.bicep
+++ b/infra/bicep/modules/web/web-app-slot.bicep
@@ -28,6 +28,7 @@ resource slot 'Microsoft.Web/sites/slots@2023-12-01' = {
   name: slotName
   location: location
   tags: tags
+  kind: 'app,linux'
   identity: {
     type: 'SystemAssigned'
   }

--- a/infra/bicep/modules/web/web-app-slot.bicep
+++ b/infra/bicep/modules/web/web-app-slot.bicep
@@ -1,0 +1,56 @@
+@description('Name of the parent web app.')
+param webAppName string
+
+@description('Name of the deployment slot, for example staging.')
+param slotName string = 'staging'
+
+@description('Azure region for the slot.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the App Service plan hosting the slot.')
+param appServicePlanId string
+
+@description('Linux runtime stack, for example DOTNETCORE|8.0 or NODE|20-lts.')
+param linuxFxVersion string = 'DOTNETCORE|8.0'
+
+@description('Application settings as name/value pairs.')
+param appSettings array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: webAppName
+}
+
+resource slot 'Microsoft.Web/sites/slots@2023-12-01' = {
+  parent: webApp
+  name: slotName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlanId
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: appSettings
+    }
+  }
+}
+
+@description('Resource ID of the deployment slot.')
+output id string = slot.id
+
+@description('Name of the deployment slot.')
+output name string = slot.name
+
+@description('Default host name of the slot.')
+output defaultHostName string = slot.properties.defaultHostName
+
+@description('Principal ID of the slot system-assigned managed identity.')
+output principalId string = slot.identity.principalId

--- a/infra/bicep/modules/web/web-app.bicep
+++ b/infra/bicep/modules/web/web-app.bicep
@@ -1,0 +1,69 @@
+@description('Name of the web app.')
+param name string
+
+@description('Azure region for the web app.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the App Service plan hosting this app.')
+param appServicePlanId string
+
+@description('Linux runtime stack, for example DOTNETCORE|8.0 or NODE|20-lts.')
+param linuxFxVersion string = 'DOTNETCORE|8.0'
+
+@description('Application Insights connection string. Empty omits the setting.')
+param appInsightsConnectionString string = ''
+
+@description('Application Insights instrumentation key. Empty omits the setting.')
+param appInsightsInstrumentationKey string = ''
+
+@description('Additional application settings as name/value pairs.')
+param additionalAppSettings array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+var appInsightsSettings = concat(
+  empty(appInsightsConnectionString) ? [] : [
+    {
+      name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+      value: appInsightsConnectionString
+    }
+  ],
+  empty(appInsightsInstrumentationKey) ? [] : [
+    {
+      name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+      value: appInsightsInstrumentationKey
+    }
+  ]
+)
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: name
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlanId
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: concat(appInsightsSettings, additionalAppSettings)
+    }
+  }
+}
+
+@description('Resource ID of the web app.')
+output id string = webApp.id
+
+@description('Name of the web app.')
+output name string = webApp.name
+
+@description('Default host name of the web app.')
+output defaultHostName string = webApp.properties.defaultHostName
+
+@description('Principal ID of the system-assigned managed identity.')
+output principalId string = webApp.identity.principalId

--- a/infra/bicep/modules/web/web-app.bicep
+++ b/infra/bicep/modules/web/web-app.bicep
@@ -41,6 +41,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
   name: name
   location: location
   tags: tags
+  kind: 'app,linux'
   identity: {
     type: 'SystemAssigned'
   }


### PR DESCRIPTION
## Summary

Adds 18 reusable, independently deployable Bicep capability modules under `infra/bicep/modules/`, forming the foundation library for the Practical Journey epic.

## Details

**foundation/ (7)**
- `log-analytics-workspace` · `application-insights` · `key-vault` (RBAC auth, soft-delete, purge protection) · `role-assignment` (RG-scope, deterministic GUID) · `action-group` · `metric-alerts` (static-threshold, optional action group) · `autoscale-settings` (scale-out/scale-in profile)

**web/ (4)**
- `app-service-plan` (Linux) · `web-app` (SystemAssigned identity, App Insights app settings, TLS 1.2, FTPS disabled) · `web-app-slot` (staging slot) · `front-door-standard` (profile + endpoint + WAF policy)

**data/ (3)**
- `sql-logical-server` (`@secure()` admin password, public access disabled, TLS 1.2) · `sql-database` · `sql-failover-group` (automatic)

**network/ (4)**
- `virtual-network` (subnet arrays + subnet ID outputs) · `private-dns-zone` (+ vnet links) · `private-endpoint-sql` (groupId `sqlServer`) · `private-endpoint-webapp` (groupId `sites`)

Design: every parameter carries `@description()`; no hardcoded names/locations (location defaults to `resourceGroup().location`); outputs expose IDs plus chaining properties; parent references use `existing`; modules carry no module-to-module dependencies.

## Verification

- `az bicep build --file <module> --stdout` succeeds for **all 18** modules — 0 errors, 0 warnings (safe-access linter warning resolved on `virtual-network`).
- No stray compiled `.json` artifacts committed.

Part of #14