### PR TITLE
feat: Stage 1 — MVP infrastructure and driver scripts (#15)

### DIFF
--- a/docs/practical-journey/stage-01-mvp.md
+++ b/docs/practical-journey/stage-01-mvp.md
@@ -1,0 +1,145 @@
+---
+description: Stage 1 of the Practical Journey — deploy a public ASP.NET Core web app backed by Azure SQL Database with day-one telemetry, then tear it down.
+content_sources:
+  diagrams:
+    - id: stage-01-mvp-architecture
+      type: flowchart
+      source: mslearn-adapted
+      mslearn_url: https://learn.microsoft.com/en-us/azure/architecture/web-apps/app-service/architectures/baseline-zone-redundant
+---
+# Stage 1 — MVP
+
+> **Trigger:** "We need a real public web app online this week."
+
+Stage 1 stands up the smallest thing that is genuinely production-shaped: a public ASP.NET Core web app on Azure App Service, backed by Azure SQL Database, with Application Insights wired in from the first deploy. Everything lives in one resource group so the whole stage tears down with a single command.
+
+This stage deploys the [Practical Storefront](https://github.com/yeongseon/azure-architecture-practical-guide/tree/main/src/practical-storefront) sample app using the [foundation Bicep modules](https://github.com/yeongseon/azure-architecture-practical-guide/tree/main/infra/bicep/modules) composed by [`stages/stage-01-mvp/main.bicep`](https://github.com/yeongseon/azure-architecture-practical-guide/tree/main/infra/bicep/stages/stage-01-mvp).
+
+## Before you start
+
+Read these foundations first — Stage 1 applies the decisions they describe:
+
+- [Compute selection basics](../platform/compute-selection-basics.md) — why App Service (managed PaaS) over VMs.
+- [Data selection basics](../platform/data-selection-basics.md) — why Azure SQL Database for a relational MVP.
+- [Resource organization](../platform/resource-organization.md) — why a single resource group per stage.
+- [Observability foundations](../platform/observability-foundations.md) — why telemetry ships on day one.
+- [Service selection patterns](../patterns/service-selection-patterns.md) — the selection logic behind this baseline.
+
+## What you'll build
+
+<!-- diagram-id: stage-01-mvp-architecture -->
+```mermaid
+flowchart TD
+    User[Public user] -->|HTTPS 443| WebApp[App Service Web App<br/>Linux B1, DOTNETCORE 8.0]
+    WebApp -->|SQL 1433, TLS 1.2| SQL[(Azure SQL Database<br/>Basic tier)]
+    WebApp -->|Telemetry| AI[Application Insights]
+    AI --> LA[Log Analytics workspace<br/>7-day retention]
+    subgraph RG[Single resource group]
+        WebApp
+        SQL
+        AI
+        LA
+    end
+```
+
+| Resource | SKU / Tier | Role |
+|---|---|---|
+| App Service plan | Linux **B1** (Basic) | Compute host |
+| Web App | `DOTNETCORE\|8.0`, HTTPS-only | Runs the Storefront app |
+| Azure SQL logical server | v12.0, TLS 1.2 | Database server |
+| SQL Database | **Basic** (2 GB) | Catalog and order data |
+| Application Insights | Workspace-based | Request and dependency telemetry |
+| Log Analytics workspace | 7-day retention | Telemetry backend |
+
+**Cost:** ~$0.09–$0.13/hour. **Time:** 20–30 minutes.
+
+## Prerequisites
+
+- Azure CLI logged in (`az login`) with rights to create resource groups.
+- A strong SQL administrator password exported as `SQL_ADMIN_PASSWORD` (never commit it).
+
+## Deploy
+
+The generic driver scripts under `scripts/practical/` wrap the Bicep deployment with a repeatable deploy → verify → destroy flow:
+
+```bash
+export SQL_ADMIN_PASSWORD='<choose-a-strong-password>'
+
+scripts/practical/deploy-stage.sh stage-01
+```
+
+The script creates the resource group, runs the deployment, and prints the web app name, URL, and Application Insights name.
+
+To deploy the Bicep directly instead:
+
+```bash
+az group create --resource-group rg-practical-storefront-stage01 --location koreacentral
+
+az deployment group create \
+  --resource-group rg-practical-storefront-stage01 \
+  --template-file infra/bicep/stages/stage-01-mvp/main.bicep \
+  --parameters infra/bicep/stages/stage-01-mvp/main.bicepparam \
+  --parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"
+```
+
+## Verify
+
+```bash
+scripts/practical/verify-stage.sh stage-01
+```
+
+This runs two smoke tests:
+
+1. **HTTP smoke** — `GET /` returns `200`, `GET /healthz` returns `{"status":"Healthy"}`, `GET /ops/info` returns JSON with a `version` field.
+2. **SQL smoke** — confirms the database is reachable on TCP 1433.
+
+Confirm telemetry is flowing after a few requests:
+
+```bash
+az monitor app-insights metrics show \
+  --app <appInsightsName> \
+  --resource-group rg-practical-storefront-stage01 \
+  --metric requests/count \
+  --interval PT5M
+```
+
+A `value` greater than `0` confirms Application Insights is capturing requests.
+
+See [`labs/trunk/stage-01-mvp/`](https://github.com/yeongseon/azure-architecture-practical-guide/tree/main/labs/trunk/stage-01-mvp) for the full checklist, sample requests, and expected results.
+
+## Best practices embedded in this stage
+
+- **Managed PaaS over VMs** — no OS to patch; App Service and Azure SQL are fully managed.
+- **Stateless app design** — all durable state is in SQL, so the app can scale out later without change.
+- **Telemetry on day 1** — the Application Insights connection string is injected at deploy time, not bolted on later.
+- **Single resource group** — the entire stage is created and destroyed as one unit.
+
+> Stage 1 intentionally uses SQL authentication and a public SQL endpoint to keep the first deploy simple. This is **not** a production target. Later stages migrate to managed identity, Key Vault, and private endpoints.
+
+## Clean up
+
+```bash
+scripts/practical/destroy-stage.sh stage-01
+```
+
+This deletes the resource group and everything in it.
+
+## Go deeper
+
+- [Public web and API — baseline](../workload-guides/public-web-api/baseline.md) — the workload blueprint this stage instantiates.
+- [Compute selection cheatsheet](../reference/compute-selection-cheatsheet.md)
+- [Data selection cheatsheet](../reference/data-selection-cheatsheet.md)
+- [Design Lab 01 — public web baseline](../design-labs/lab-01-public-web-baseline.md)
+
+## See Also
+
+- [Compute selection basics](../platform/compute-selection-basics.md)
+- [Data selection basics](../platform/data-selection-basics.md)
+- [Observability foundations](../platform/observability-foundations.md)
+- [Public web and API — baseline](../workload-guides/public-web-api/baseline.md)
+
+## Sources
+
+- [Azure App Service overview](https://learn.microsoft.com/en-us/azure/app-service/overview)
+- [Azure SQL Database — PaaS overview](https://learn.microsoft.com/en-us/azure/azure-sql/database/sql-database-paas-overview)
+- [Application Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)

--- a/infra/bicep/modules/data/sql-database.bicep
+++ b/infra/bicep/modules/data/sql-database.bicep
@@ -1,0 +1,44 @@
+@description('Name of the parent SQL logical server.')
+param sqlServerName string
+
+@description('Name of the database.')
+param name string
+
+@description('Azure region for the database.')
+param location string = resourceGroup().location
+
+@description('SKU name for the database, for example S0.')
+param skuName string = 'S0'
+
+@description('SKU tier for the database.')
+param skuTier string = 'Standard'
+
+@description('Maximum database size in bytes.')
+param maxSizeBytes int = 268435456000
+
+@description('Resource tags.')
+param tags object = {}
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+  name: sqlServerName
+}
+
+resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuTier
+  }
+  properties: {
+    maxSizeBytes: maxSizeBytes
+  }
+}
+
+@description('Resource ID of the database.')
+output id string = database.id
+
+@description('Name of the database.')
+output name string = database.name

--- a/infra/bicep/modules/data/sql-database.bicep
+++ b/infra/bicep/modules/data/sql-database.bicep
@@ -19,11 +19,11 @@ param maxSizeBytes int = 268435456000
 @description('Resource tags.')
 param tags object = {}
 
-resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' existing = {
   name: sqlServerName
 }
 
-resource database 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+resource database 'Microsoft.Sql/servers/databases@2021-11-01' = {
   parent: sqlServer
   name: name
   location: location

--- a/infra/bicep/modules/data/sql-failover-group.bicep
+++ b/infra/bicep/modules/data/sql-failover-group.bicep
@@ -13,11 +13,11 @@ param databaseIds array
 @description('Grace period in minutes before automatic failover with data loss.')
 param gracePeriodMinutes int = 60
 
-resource primaryServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+resource primaryServer 'Microsoft.Sql/servers@2021-11-01' existing = {
   name: primaryServerName
 }
 
-resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2023-08-01-preview' = {
+resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2021-11-01' = {
   parent: primaryServer
   name: name
   properties: {

--- a/infra/bicep/modules/data/sql-failover-group.bicep
+++ b/infra/bicep/modules/data/sql-failover-group.bicep
@@ -1,0 +1,41 @@
+@description('Name of the primary SQL logical server.')
+param primaryServerName string
+
+@description('Name of the failover group.')
+param name string
+
+@description('Resource ID of the partner (secondary) SQL logical server.')
+param partnerServerId string
+
+@description('Resource IDs of the databases to include in the failover group.')
+param databaseIds array
+
+@description('Grace period in minutes before automatic failover with data loss.')
+param gracePeriodMinutes int = 60
+
+resource primaryServer 'Microsoft.Sql/servers@2023-08-01-preview' existing = {
+  name: primaryServerName
+}
+
+resource failoverGroup 'Microsoft.Sql/servers/failoverGroups@2023-08-01-preview' = {
+  parent: primaryServer
+  name: name
+  properties: {
+    readWriteEndpoint: {
+      failoverPolicy: 'Automatic'
+      failoverWithDataLossGracePeriodMinutes: gracePeriodMinutes
+    }
+    partnerServers: [
+      {
+        id: partnerServerId
+      }
+    ]
+    databases: databaseIds
+  }
+}
+
+@description('Resource ID of the failover group.')
+output id string = failoverGroup.id
+
+@description('Name of the failover group.')
+output name string = failoverGroup.name

--- a/infra/bicep/modules/data/sql-logical-server.bicep
+++ b/infra/bicep/modules/data/sql-logical-server.bicep
@@ -21,7 +21,7 @@ param publicNetworkAccess string = 'Disabled'
 @description('Resource tags.')
 param tags object = {}
 
-resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   name: name
   location: location
   tags: tags

--- a/infra/bicep/modules/data/sql-logical-server.bicep
+++ b/infra/bicep/modules/data/sql-logical-server.bicep
@@ -1,0 +1,44 @@
+@description('Name of the SQL logical server.')
+param name string
+
+@description('Azure region for the server.')
+param location string = resourceGroup().location
+
+@description('Administrator login name.')
+param administratorLogin string
+
+@description('Administrator login password.')
+@secure()
+param administratorLoginPassword string
+
+@description('Allow public network access to the server.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Disabled'
+
+@description('Resource tags.')
+param tags object = {}
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    version: '12.0'
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: publicNetworkAccess
+  }
+}
+
+@description('Resource ID of the SQL logical server.')
+output id string = sqlServer.id
+
+@description('Name of the SQL logical server.')
+output name string = sqlServer.name
+
+@description('Fully qualified domain name of the server.')
+output fullyQualifiedDomainName string = sqlServer.properties.fullyQualifiedDomainName

--- a/infra/bicep/modules/foundation/action-group.bicep
+++ b/infra/bicep/modules/foundation/action-group.bicep
@@ -1,0 +1,36 @@
+@description('Name of the action group.')
+param name string
+
+@description('Short name (max 12 characters) shown in notifications.')
+@maxLength(12)
+param groupShortName string
+
+@description('Email receivers. Each item requires a name and emailAddress.')
+param emailReceivers array = []
+
+@description('Enable the action group.')
+param enabled bool = true
+
+@description('Resource tags.')
+param tags object = {}
+
+resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: name
+  location: 'Global'
+  tags: tags
+  properties: {
+    groupShortName: groupShortName
+    enabled: enabled
+    emailReceivers: [for receiver in emailReceivers: {
+      name: receiver.name
+      emailAddress: receiver.emailAddress
+      useCommonAlertSchema: true
+    }]
+  }
+}
+
+@description('Resource ID of the action group.')
+output id string = actionGroup.id
+
+@description('Name of the action group.')
+output name string = actionGroup.name

--- a/infra/bicep/modules/foundation/application-insights.bicep
+++ b/infra/bicep/modules/foundation/application-insights.bicep
@@ -1,0 +1,38 @@
+@description('Name of the Application Insights component.')
+param name string
+
+@description('Azure region for the component.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the Log Analytics workspace backing this component.')
+param workspaceResourceId string
+
+@description('Application type.')
+param applicationType string = 'web'
+
+@description('Resource tags.')
+param tags object = {}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: name
+  location: location
+  tags: tags
+  kind: applicationType
+  properties: {
+    Application_Type: applicationType
+    WorkspaceResourceId: workspaceResourceId
+    IngestionMode: 'LogAnalytics'
+  }
+}
+
+@description('Resource ID of the Application Insights component.')
+output id string = appInsights.id
+
+@description('Name of the Application Insights component.')
+output name string = appInsights.name
+
+@description('Instrumentation key for the component.')
+output instrumentationKey string = appInsights.properties.InstrumentationKey
+
+@description('Connection string for the component.')
+output connectionString string = appInsights.properties.ConnectionString

--- a/infra/bicep/modules/foundation/autoscale-settings.bicep
+++ b/infra/bicep/modules/foundation/autoscale-settings.bicep
@@ -1,0 +1,98 @@
+@description('Name of the autoscale setting.')
+param name string
+
+@description('Azure region for the autoscale setting.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the target resource to scale, for example an App Service plan.')
+param targetResourceId string
+
+@description('Minimum instance count.')
+param minimumCapacity int = 1
+
+@description('Maximum instance count.')
+param maximumCapacity int = 10
+
+@description('Default instance count when no rule applies.')
+param defaultCapacity int = 1
+
+@description('Metric evaluated for scaling decisions.')
+param metricName string = 'CpuPercentage'
+
+@description('Metric namespace of the target resource.')
+param metricNamespace string = 'Microsoft.Web/serverfarms'
+
+@description('Scale-out threshold. Exceeding this adds an instance.')
+param scaleOutThreshold int = 70
+
+@description('Scale-in threshold. Falling below this removes an instance.')
+param scaleInThreshold int = 30
+
+@description('Resource tags.')
+param tags object = {}
+
+resource autoscale 'Microsoft.Insights/autoscaleSettings@2022-10-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    enabled: true
+    targetResourceUri: targetResourceId
+    profiles: [
+      {
+        name: 'Default profile'
+        capacity: {
+          minimum: string(minimumCapacity)
+          maximum: string(maximumCapacity)
+          default: string(defaultCapacity)
+        }
+        rules: [
+          {
+            metricTrigger: {
+              metricName: metricName
+              metricNamespace: metricNamespace
+              metricResourceUri: targetResourceId
+              timeGrain: 'PT1M'
+              statistic: 'Average'
+              timeWindow: 'PT5M'
+              timeAggregation: 'Average'
+              operator: 'GreaterThan'
+              threshold: scaleOutThreshold
+            }
+            scaleAction: {
+              direction: 'Increase'
+              type: 'ChangeCount'
+              value: '1'
+              cooldown: 'PT5M'
+            }
+          }
+          {
+            metricTrigger: {
+              metricName: metricName
+              metricNamespace: metricNamespace
+              metricResourceUri: targetResourceId
+              timeGrain: 'PT1M'
+              statistic: 'Average'
+              timeWindow: 'PT5M'
+              timeAggregation: 'Average'
+              operator: 'LessThan'
+              threshold: scaleInThreshold
+            }
+            scaleAction: {
+              direction: 'Decrease'
+              type: 'ChangeCount'
+              value: '1'
+              cooldown: 'PT5M'
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the autoscale setting.')
+output id string = autoscale.id
+
+@description('Name of the autoscale setting.')
+output name string = autoscale.name

--- a/infra/bicep/modules/foundation/key-vault.bicep
+++ b/infra/bicep/modules/foundation/key-vault.bicep
@@ -16,6 +16,13 @@ param softDeleteRetentionInDays int = 90
 @description('Enable purge protection to prevent permanent deletion during the retention period.')
 param enablePurgeProtection bool = true
 
+@description('Allow public network access to the vault. Defaults to Disabled for a secure baseline.')
+@allowed([
+  'Enabled'
+  'Disabled'
+])
+param publicNetworkAccess string = 'Disabled'
+
 @description('Resource tags.')
 param tags object = {}
 
@@ -33,6 +40,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enableSoftDelete: true
     softDeleteRetentionInDays: softDeleteRetentionInDays
     enablePurgeProtection: enablePurgeProtection ? true : null
+    publicNetworkAccess: publicNetworkAccess
   }
 }
 

--- a/infra/bicep/modules/foundation/key-vault.bicep
+++ b/infra/bicep/modules/foundation/key-vault.bicep
@@ -1,0 +1,46 @@
+@description('Name of the key vault.')
+param name string
+
+@description('Azure region for the key vault.')
+param location string = resourceGroup().location
+
+@description('Pricing tier for the key vault.')
+param sku string = 'standard'
+
+@description('Enable Azure RBAC for data-plane authorization instead of access policies.')
+param enableRbacAuthorization bool = true
+
+@description('Number of days to retain soft-deleted vaults and secrets.')
+param softDeleteRetentionInDays int = 90
+
+@description('Enable purge protection to prevent permanent deletion during the retention period.')
+param enablePurgeProtection bool = true
+
+@description('Resource tags.')
+param tags object = {}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      family: 'A'
+      name: sku
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: enableRbacAuthorization
+    enableSoftDelete: true
+    softDeleteRetentionInDays: softDeleteRetentionInDays
+    enablePurgeProtection: enablePurgeProtection ? true : null
+  }
+}
+
+@description('Resource ID of the key vault.')
+output id string = keyVault.id
+
+@description('Name of the key vault.')
+output name string = keyVault.name
+
+@description('URI of the key vault for data-plane access.')
+output vaultUri string = keyVault.properties.vaultUri

--- a/infra/bicep/modules/foundation/log-analytics-workspace.bicep
+++ b/infra/bicep/modules/foundation/log-analytics-workspace.bicep
@@ -1,0 +1,38 @@
+@description('Name of the Log Analytics workspace.')
+param name string
+
+@description('Azure region for the workspace.')
+param location string = resourceGroup().location
+
+@description('Pricing tier for the workspace.')
+param sku string = 'PerGB2018'
+
+@description('Data retention in days.')
+param retentionInDays int = 30
+
+@description('Resource tags.')
+param tags object = {}
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: sku
+    }
+    retentionInDays: retentionInDays
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+  }
+}
+
+@description('Resource ID of the Log Analytics workspace.')
+output id string = workspace.id
+
+@description('Name of the Log Analytics workspace.')
+output name string = workspace.name
+
+@description('Customer (workspace) ID used by data sources.')
+output customerId string = workspace.properties.customerId

--- a/infra/bicep/modules/foundation/metric-alerts.bicep
+++ b/infra/bicep/modules/foundation/metric-alerts.bicep
@@ -1,0 +1,99 @@
+@description('Name of the metric alert rule.')
+param name string
+
+@description('Description of what the alert monitors.')
+param alertDescription string = ''
+
+@description('Resource ID of the target resource being monitored.')
+param targetResourceId string
+
+@description('Metric namespace of the target resource, for example Microsoft.Web/sites.')
+param metricNamespace string
+
+@description('Name of the metric to evaluate.')
+param metricName string
+
+@description('Comparison operator for the threshold.')
+@allowed([
+  'GreaterThan'
+  'GreaterThanOrEqual'
+  'LessThan'
+  'LessThanOrEqual'
+])
+param operator string = 'GreaterThan'
+
+@description('Aggregation applied to the metric before comparison.')
+@allowed([
+  'Average'
+  'Minimum'
+  'Maximum'
+  'Total'
+  'Count'
+])
+param timeAggregation string = 'Average'
+
+@description('Threshold value that triggers the alert.')
+param threshold int
+
+@description('Alert severity, 0 (critical) to 4 (verbose).')
+@allowed([
+  0
+  1
+  2
+  3
+  4
+])
+param severity int = 3
+
+@description('How often the rule evaluates, ISO 8601 duration.')
+param evaluationFrequency string = 'PT5M'
+
+@description('Time window over which the metric is aggregated, ISO 8601 duration.')
+param windowSize string = 'PT15M'
+
+@description('Resource ID of the action group to notify. Empty disables notification.')
+param actionGroupId string = ''
+
+@description('Resource tags.')
+param tags object = {}
+
+resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: name
+  location: 'global'
+  tags: tags
+  properties: {
+    description: alertDescription
+    severity: severity
+    enabled: true
+    scopes: [
+      targetResourceId
+    ]
+    evaluationFrequency: evaluationFrequency
+    windowSize: windowSize
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'Metric1'
+          metricNamespace: metricNamespace
+          metricName: metricName
+          operator: operator
+          timeAggregation: timeAggregation
+          threshold: threshold
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: empty(actionGroupId) ? [] : [
+      {
+        actionGroupId: actionGroupId
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the metric alert.')
+output id string = metricAlert.id
+
+@description('Name of the metric alert.')
+output name string = metricAlert.name

--- a/infra/bicep/modules/foundation/role-assignment.bicep
+++ b/infra/bicep/modules/foundation/role-assignment.bicep
@@ -1,0 +1,30 @@
+@description('Principal (object) ID that receives the role assignment.')
+param principalId string
+
+@description('Resource ID of the role definition to assign.')
+param roleDefinitionId string
+
+@description('Type of principal receiving the assignment.')
+@allowed([
+  'User'
+  'Group'
+  'ServicePrincipal'
+  'ForeignGroup'
+  'Device'
+])
+param principalType string = 'ServicePrincipal'
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, principalId, roleDefinitionId)
+  properties: {
+    principalId: principalId
+    roleDefinitionId: roleDefinitionId
+    principalType: principalType
+  }
+}
+
+@description('Resource ID of the role assignment.')
+output id string = roleAssignment.id
+
+@description('Name (GUID) of the role assignment.')
+output name string = roleAssignment.name

--- a/infra/bicep/modules/network/private-dns-zone.bicep
+++ b/infra/bicep/modules/network/private-dns-zone.bicep
@@ -1,0 +1,32 @@
+@description('Name of the private DNS zone, for example privatelink.database.windows.net.')
+param name string
+
+@description('Virtual networks to link to this zone. Each item requires name and virtualNetworkId.')
+param virtualNetworkLinks array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: name
+  location: 'global'
+  tags: tags
+}
+
+resource links 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = [for link in virtualNetworkLinks: {
+  parent: privateDnsZone
+  name: link.name
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: link.virtualNetworkId
+    }
+  }
+}]
+
+@description('Resource ID of the private DNS zone.')
+output id string = privateDnsZone.id
+
+@description('Name of the private DNS zone.')
+output name string = privateDnsZone.name

--- a/infra/bicep/modules/network/private-endpoint-sql.bicep
+++ b/infra/bicep/modules/network/private-endpoint-sql.bicep
@@ -1,0 +1,60 @@
+@description('Name of the private endpoint.')
+param name string
+
+@description('Azure region for the private endpoint.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the subnet hosting the private endpoint.')
+param subnetId string
+
+@description('Resource ID of the target SQL logical server.')
+param sqlServerId string
+
+@description('Resource ID of the private DNS zone for SQL. Empty skips DNS integration.')
+param privateDnsZoneId string = ''
+
+@description('Resource tags.')
+param tags object = {}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${name}-connection'
+        properties: {
+          privateLinkServiceId: sqlServerId
+          groupIds: [
+            'sqlServer'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!empty(privateDnsZoneId)) {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'sql'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the private endpoint.')
+output id string = privateEndpoint.id
+
+@description('Name of the private endpoint.')
+output name string = privateEndpoint.name

--- a/infra/bicep/modules/network/private-endpoint-webapp.bicep
+++ b/infra/bicep/modules/network/private-endpoint-webapp.bicep
@@ -1,0 +1,60 @@
+@description('Name of the private endpoint.')
+param name string
+
+@description('Azure region for the private endpoint.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the subnet hosting the private endpoint.')
+param subnetId string
+
+@description('Resource ID of the target web app.')
+param webAppId string
+
+@description('Resource ID of the private DNS zone for the web app. Empty skips DNS integration.')
+param privateDnsZoneId string = ''
+
+@description('Resource tags.')
+param tags object = {}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${name}-connection'
+        properties: {
+          privateLinkServiceId: webAppId
+          groupIds: [
+            'sites'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource dnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!empty(privateDnsZoneId)) {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'sites'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
+@description('Resource ID of the private endpoint.')
+output id string = privateEndpoint.id
+
+@description('Name of the private endpoint.')
+output name string = privateEndpoint.name

--- a/infra/bicep/modules/network/virtual-network.bicep
+++ b/infra/bicep/modules/network/virtual-network.bicep
@@ -1,0 +1,43 @@
+@description('Name of the virtual network.')
+param name string
+
+@description('Azure region for the virtual network.')
+param location string = resourceGroup().location
+
+@description('Address prefixes for the virtual network.')
+param addressPrefixes array = [
+  '10.0.0.0/16'
+]
+
+@description('Subnets to create. Each item requires name and addressPrefix.')
+param subnets array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: addressPrefixes
+    }
+    subnets: [for subnet in subnets: {
+      name: subnet.name
+      properties: {
+        addressPrefix: subnet.addressPrefix
+        privateEndpointNetworkPolicies: subnet.?privateEndpointNetworkPolicies ?? 'Disabled'
+      }
+    }]
+  }
+}
+
+@description('Resource ID of the virtual network.')
+output id string = virtualNetwork.id
+
+@description('Name of the virtual network.')
+output name string = virtualNetwork.name
+
+@description('Resource IDs of the created subnets.')
+output subnetIds array = [for (subnet, i) in subnets: virtualNetwork.properties.subnets[i].id]

--- a/infra/bicep/modules/web/app-service-plan.bicep
+++ b/infra/bicep/modules/web/app-service-plan.bicep
@@ -1,0 +1,41 @@
+@description('Name of the App Service plan.')
+param name string
+
+@description('Azure region for the plan.')
+param location string = resourceGroup().location
+
+@description('SKU name for the plan, for example P1v3.')
+param skuName string = 'P1v3'
+
+@description('SKU tier for the plan.')
+param skuTier string = 'PremiumV3'
+
+@description('Number of worker instances.')
+param capacity int = 1
+
+@description('Host the plan on Linux.')
+param linux bool = true
+
+@description('Resource tags.')
+param tags object = {}
+
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: skuName
+    tier: skuTier
+    capacity: capacity
+  }
+  kind: linux ? 'linux' : 'app'
+  properties: {
+    reserved: linux
+  }
+}
+
+@description('Resource ID of the App Service plan.')
+output id string = plan.id
+
+@description('Name of the App Service plan.')
+output name string = plan.name

--- a/infra/bicep/modules/web/front-door-standard.bicep
+++ b/infra/bicep/modules/web/front-door-standard.bicep
@@ -1,0 +1,79 @@
+@description('Name of the Front Door profile.')
+param name string
+
+@description('Name of the Front Door endpoint.')
+param endpointName string = name
+
+@description('SKU for the Front Door profile.')
+@allowed([
+  'Standard_AzureFrontDoor'
+  'Premium_AzureFrontDoor'
+])
+param skuName string = 'Standard_AzureFrontDoor'
+
+@description('Name of the WAF policy.')
+param wafPolicyName string = '${replace(name, '-', '')}waf'
+
+@description('WAF policy mode.')
+@allowed([
+  'Detection'
+  'Prevention'
+])
+param wafMode string = 'Prevention'
+
+@description('Resource tags.')
+param tags object = {}
+
+resource profile 'Microsoft.Cdn/profiles@2023-05-01' = {
+  name: name
+  location: 'Global'
+  tags: tags
+  sku: {
+    name: skuName
+  }
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/afdEndpoints@2023-05-01' = {
+  parent: profile
+  name: endpointName
+  location: 'Global'
+  properties: {
+    enabledState: 'Enabled'
+  }
+}
+
+resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2022-05-01' = {
+  name: wafPolicyName
+  location: 'Global'
+  tags: tags
+  sku: {
+    name: skuName
+  }
+  properties: {
+    policySettings: {
+      enabledState: 'Enabled'
+      mode: wafMode
+    }
+    managedRules: {
+      managedRuleSets: [
+        {
+          ruleSetType: 'Microsoft_DefaultRuleSet'
+          ruleSetVersion: '2.1'
+          ruleSetAction: 'Block'
+        }
+      ]
+    }
+  }
+}
+
+@description('Resource ID of the Front Door profile.')
+output profileId string = profile.id
+
+@description('Resource ID of the Front Door endpoint.')
+output endpointId string = endpoint.id
+
+@description('Host name of the Front Door endpoint.')
+output endpointHostName string = endpoint.properties.hostName
+
+@description('Resource ID of the WAF policy.')
+output wafPolicyId string = wafPolicy.id

--- a/infra/bicep/modules/web/front-door-standard.bicep
+++ b/infra/bicep/modules/web/front-door-standard.bicep
@@ -66,6 +66,31 @@ resource wafPolicy 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@20
   }
 }
 
+resource securityPolicy 'Microsoft.Cdn/profiles/securityPolicies@2023-05-01' = {
+  parent: profile
+  name: '${name}-security-policy'
+  properties: {
+    parameters: {
+      type: 'WebApplicationFirewall'
+      wafPolicy: {
+        id: wafPolicy.id
+      }
+      associations: [
+        {
+          domains: [
+            {
+              id: endpoint.id
+            }
+          ]
+          patternsToMatch: [
+            '/*'
+          ]
+        }
+      ]
+    }
+  }
+}
+
 @description('Resource ID of the Front Door profile.')
 output profileId string = profile.id
 

--- a/infra/bicep/modules/web/web-app-slot.bicep
+++ b/infra/bicep/modules/web/web-app-slot.bicep
@@ -28,6 +28,7 @@ resource slot 'Microsoft.Web/sites/slots@2023-12-01' = {
   name: slotName
   location: location
   tags: tags
+  kind: 'app,linux'
   identity: {
     type: 'SystemAssigned'
   }

--- a/infra/bicep/modules/web/web-app-slot.bicep
+++ b/infra/bicep/modules/web/web-app-slot.bicep
@@ -1,0 +1,56 @@
+@description('Name of the parent web app.')
+param webAppName string
+
+@description('Name of the deployment slot, for example staging.')
+param slotName string = 'staging'
+
+@description('Azure region for the slot.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the App Service plan hosting the slot.')
+param appServicePlanId string
+
+@description('Linux runtime stack, for example DOTNETCORE|8.0 or NODE|20-lts.')
+param linuxFxVersion string = 'DOTNETCORE|8.0'
+
+@description('Application settings as name/value pairs.')
+param appSettings array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: webAppName
+}
+
+resource slot 'Microsoft.Web/sites/slots@2023-12-01' = {
+  parent: webApp
+  name: slotName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlanId
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: appSettings
+    }
+  }
+}
+
+@description('Resource ID of the deployment slot.')
+output id string = slot.id
+
+@description('Name of the deployment slot.')
+output name string = slot.name
+
+@description('Default host name of the slot.')
+output defaultHostName string = slot.properties.defaultHostName
+
+@description('Principal ID of the slot system-assigned managed identity.')
+output principalId string = slot.identity.principalId

--- a/infra/bicep/modules/web/web-app.bicep
+++ b/infra/bicep/modules/web/web-app.bicep
@@ -1,0 +1,69 @@
+@description('Name of the web app.')
+param name string
+
+@description('Azure region for the web app.')
+param location string = resourceGroup().location
+
+@description('Resource ID of the App Service plan hosting this app.')
+param appServicePlanId string
+
+@description('Linux runtime stack, for example DOTNETCORE|8.0 or NODE|20-lts.')
+param linuxFxVersion string = 'DOTNETCORE|8.0'
+
+@description('Application Insights connection string. Empty omits the setting.')
+param appInsightsConnectionString string = ''
+
+@description('Application Insights instrumentation key. Empty omits the setting.')
+param appInsightsInstrumentationKey string = ''
+
+@description('Additional application settings as name/value pairs.')
+param additionalAppSettings array = []
+
+@description('Resource tags.')
+param tags object = {}
+
+var appInsightsSettings = concat(
+  empty(appInsightsConnectionString) ? [] : [
+    {
+      name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+      value: appInsightsConnectionString
+    }
+  ],
+  empty(appInsightsInstrumentationKey) ? [] : [
+    {
+      name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
+      value: appInsightsInstrumentationKey
+    }
+  ]
+)
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: name
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlanId
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      appSettings: concat(appInsightsSettings, additionalAppSettings)
+    }
+  }
+}
+
+@description('Resource ID of the web app.')
+output id string = webApp.id
+
+@description('Name of the web app.')
+output name string = webApp.name
+
+@description('Default host name of the web app.')
+output defaultHostName string = webApp.properties.defaultHostName
+
+@description('Principal ID of the system-assigned managed identity.')
+output principalId string = webApp.identity.principalId

--- a/infra/bicep/modules/web/web-app.bicep
+++ b/infra/bicep/modules/web/web-app.bicep
@@ -41,6 +41,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
   name: name
   location: location
   tags: tags
+  kind: 'app,linux'
   identity: {
     type: 'SystemAssigned'
   }

--- a/infra/bicep/stages/stage-01-mvp/README.md
+++ b/infra/bicep/stages/stage-01-mvp/README.md
@@ -1,0 +1,72 @@
+# Stage 1 — MVP Infrastructure
+
+This directory deploys the Stage 1 MVP baseline for the **Practical Storefront** journey: a public ASP.NET Core web app backed by Azure SQL Database, with telemetry from day one.
+
+## What gets deployed
+
+| Resource | Module | SKU / Tier | Notes |
+|---|---|---|---|
+| Log Analytics workspace | `foundation/log-analytics-workspace.bicep` | PerGB2018, 7-day retention | Telemetry backend |
+| Application Insights | `foundation/application-insights.bicep` | Workspace-based | Wired to the web app |
+| App Service plan | `web/app-service-plan.bicep` | Linux **B1** (Basic) | Single worker |
+| Web App | `web/web-app.bicep` | `DOTNETCORE\|8.0` | HTTPS-only, system-assigned identity |
+| SQL logical server | `data/sql-logical-server.bicep` | v12.0, TLS 1.2 | `publicNetworkAccess: Enabled` for Stage 1 |
+| SQL Database | `data/sql-database.bicep` | **Basic** | 2 GB max |
+| SQL firewall rule | inline (`AllowAllWindowsAzureIps`) | `0.0.0.0` | Lets Azure services reach SQL |
+
+Estimated cost: **~$0.09–$0.13/hour**. Deploy time: **20–30 minutes**.
+
+## Design intent
+
+- **Managed PaaS over VMs** — App Service and Azure SQL, no infrastructure to patch.
+- **Stateless app** — all state lives in SQL; the app can scale out later without change.
+- **Telemetry on day 1** — Application Insights connection string is injected at deploy time.
+- **Single resource group** — the whole stage tears down with one `az group delete`.
+
+> Stage 1 uses SQL authentication and a public SQL endpoint for simplicity. Later stages migrate to managed identity, Key Vault, and private endpoints. Do not treat this connection-string pattern as a production target.
+
+## Deploy
+
+Set the SQL admin password (never commit it) and deploy with the parameter file:
+
+```bash
+export SQL_ADMIN_PASSWORD='<choose-a-strong-password>'
+export RG='rg-practical-storefront-stage01'
+export LOCATION='koreacentral'
+
+az group create --resource-group "$RG" --location "$LOCATION"
+
+az deployment group create \
+  --resource-group "$RG" \
+  --template-file main.bicep \
+  --parameters main.bicepparam
+```
+
+Prefer the generic driver scripts under `scripts/practical/` for a repeatable deploy → verify → destroy flow:
+
+```bash
+scripts/practical/deploy-stage.sh stage-01
+scripts/practical/verify-stage.sh stage-01
+scripts/practical/destroy-stage.sh stage-01
+```
+
+## Outputs
+
+| Output | Purpose |
+|---|---|
+| `webAppName` | Name of the web app |
+| `webAppUrl` | Public HTTPS URL |
+| `appInsightsName` | For metric queries during verification |
+| `sqlServerFqdn` | For SQL connectivity smoke tests |
+| `sqlDatabaseName` | Target database name |
+
+## Clean up
+
+```bash
+az group delete --name "$RG" --yes --no-wait
+```
+
+## See Also
+
+- [Stage 1 — MVP walkthrough](../../../../docs/practical-journey/stage-01-mvp.md)
+- [Foundation Bicep modules](../../modules/)

--- a/infra/bicep/stages/stage-01-mvp/main.bicep
+++ b/infra/bicep/stages/stage-01-mvp/main.bicep
@@ -1,0 +1,149 @@
+targetScope = 'resourceGroup'
+
+@description('Base name used to derive all resource names. Lowercase letters and numbers only.')
+@minLength(3)
+@maxLength(12)
+param appBaseName string
+
+@description('Azure region for all Stage 1 resources.')
+param location string = resourceGroup().location
+
+@description('Administrator login for the Azure SQL logical server.')
+param sqlAdministratorLogin string
+
+@description('Administrator password for the Azure SQL logical server.')
+@secure()
+param sqlAdministratorLoginPassword string
+
+@description('Resource tags applied to every resource in the stage.')
+param tags object = {
+  stage: 'stage-01-mvp'
+  workload: 'practical-storefront'
+}
+
+var uniqueSuffix = uniqueString(resourceGroup().id)
+var logAnalyticsName = 'log-${appBaseName}-${uniqueSuffix}'
+var appInsightsName = 'appi-${appBaseName}-${uniqueSuffix}'
+var appServicePlanName = 'plan-${appBaseName}-${uniqueSuffix}'
+var webAppName = 'app-${appBaseName}-${uniqueSuffix}'
+var sqlServerName = 'sql-${appBaseName}-${uniqueSuffix}'
+var sqlDatabaseName = 'sqldb-storefront'
+
+var sqlConnectionString = 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sqlDatabaseName};Persist Security Info=False;User ID=${sqlAdministratorLogin};Password=${sqlAdministratorLoginPassword};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;'
+
+module logAnalytics '../../modules/foundation/log-analytics-workspace.bicep' = {
+  name: 'stage01-log-analytics'
+  params: {
+    name: logAnalyticsName
+    location: location
+    retentionInDays: 7
+    tags: tags
+  }
+}
+
+module appInsights '../../modules/foundation/application-insights.bicep' = {
+  name: 'stage01-app-insights'
+  params: {
+    name: appInsightsName
+    location: location
+    workspaceResourceId: logAnalytics.outputs.id
+    tags: tags
+  }
+}
+
+module appServicePlan '../../modules/web/app-service-plan.bicep' = {
+  name: 'stage01-app-service-plan'
+  params: {
+    name: appServicePlanName
+    location: location
+    skuName: 'B1'
+    skuTier: 'Basic'
+    linux: true
+    tags: tags
+  }
+}
+
+module sqlServer '../../modules/data/sql-logical-server.bicep' = {
+  name: 'stage01-sql-server'
+  params: {
+    name: sqlServerName
+    location: location
+    administratorLogin: sqlAdministratorLogin
+    administratorLoginPassword: sqlAdministratorLoginPassword
+    publicNetworkAccess: 'Enabled'
+    tags: tags
+  }
+}
+
+module sqlDatabase '../../modules/data/sql-database.bicep' = {
+  name: 'stage01-sql-database'
+  params: {
+    sqlServerName: sqlServer.outputs.name
+    name: sqlDatabaseName
+    location: location
+    skuName: 'Basic'
+    skuTier: 'Basic'
+    maxSizeBytes: 2147483648
+    tags: tags
+  }
+}
+
+resource sqlServerExisting 'Microsoft.Sql/servers@2021-11-01' existing = {
+  name: sqlServerName
+}
+
+resource allowAzureServices 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
+  parent: sqlServerExisting
+  name: 'AllowAllWindowsAzureIps'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+  dependsOn: [
+    sqlServer
+  ]
+}
+
+module webApp '../../modules/web/web-app.bicep' = {
+  name: 'stage01-web-app'
+  params: {
+    name: webAppName
+    location: location
+    appServicePlanId: appServicePlan.outputs.id
+    linuxFxVersion: 'DOTNETCORE|8.0'
+    appInsightsConnectionString: appInsights.outputs.connectionString
+    additionalAppSettings: [
+      {
+        name: 'ConnectionStrings__StorefrontDb'
+        value: sqlConnectionString
+      }
+      {
+        name: 'REGION'
+        value: location
+      }
+      {
+        name: 'ASPNETCORE_ENVIRONMENT'
+        value: 'Production'
+      }
+    ]
+    tags: tags
+  }
+  dependsOn: [
+    sqlDatabase
+  ]
+}
+
+@description('Name of the deployed web app.')
+output webAppName string = webApp.outputs.name
+
+@description('Public HTTPS URL of the deployed web app.')
+output webAppUrl string = 'https://${webApp.outputs.defaultHostName}'
+
+@description('Name of the Application Insights component.')
+output appInsightsName string = appInsights.outputs.name
+
+@description('Fully qualified domain name of the SQL logical server.')
+output sqlServerFqdn string = sqlServer.outputs.fullyQualifiedDomainName
+
+@description('Name of the SQL database.')
+output sqlDatabaseName string = sqlDatabase.outputs.name

--- a/infra/bicep/stages/stage-01-mvp/main.bicepparam
+++ b/infra/bicep/stages/stage-01-mvp/main.bicepparam
@@ -1,0 +1,6 @@
+using './main.bicep'
+
+param appBaseName = 'storefront'
+param location = 'koreacentral'
+param sqlAdministratorLogin = 'storefrontadmin'
+param sqlAdministratorLoginPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')

--- a/labs/trunk/stage-01-mvp/checklist.md
+++ b/labs/trunk/stage-01-mvp/checklist.md
@@ -1,0 +1,37 @@
+# Stage 1 — MVP Deployment Checklist
+
+Use this checklist to deploy, verify, and tear down the Stage 1 MVP baseline.
+
+## Prerequisites
+
+- [ ] Azure CLI installed and logged in (`az login`).
+- [ ] Subscription selected (`az account set --subscription <id>`).
+- [ ] Permission to create resource groups and resources.
+- [ ] Strong SQL admin password exported: `export SQL_ADMIN_PASSWORD='...'`.
+
+## Deploy
+
+- [ ] Run `scripts/practical/deploy-stage.sh stage-01`.
+- [ ] Deployment completes without errors (20–30 minutes).
+- [ ] Note the printed **web app URL** and **Application Insights name**.
+
+## Verify
+
+- [ ] `GET /` returns `200`.
+- [ ] `GET /healthz` returns `{"status":"Healthy"}`.
+- [ ] `GET /ops/info` returns JSON containing a `version` field.
+- [ ] `GET /ops/version` returns JSON containing a `version` field.
+- [ ] SQL server is reachable on TCP 1433.
+- [ ] `az monitor app-insights metrics show --metric requests/count` reports `value > 0` after a few requests.
+- [ ] `scripts/practical/verify-stage.sh stage-01` exits `0`.
+
+## Clean up
+
+- [ ] Run `scripts/practical/destroy-stage.sh stage-01`.
+- [ ] `az group show --resource-group rg-practical-storefront-stage01` eventually returns "not found".
+
+## Related
+
+- [Stage 1 — MVP walkthrough](../../../docs/practical-journey/stage-01-mvp.md)
+- [Expected results](expected-results.md)
+- [Sample requests](sample-requests.http)

--- a/labs/trunk/stage-01-mvp/expected-results.md
+++ b/labs/trunk/stage-01-mvp/expected-results.md
@@ -1,0 +1,64 @@
+# Stage 1 — MVP Expected Results
+
+This document records what a successful Stage 1 deployment and verification looks like. Use it to confirm your run matches the expected baseline.
+
+## HTTP smoke test
+
+| Request | Expected status | Expected body |
+|---|---|---|
+| `GET /` | `200` | HTML catalog page listing seeded products |
+| `GET /healthz` | `200` | `{"status":"Healthy"}` |
+| `GET /ops/info` | `200` | JSON with `version` and `region` fields |
+| `GET /ops/version` | `200` | JSON with a `version` field |
+| `GET /Home/Orders` | `200` | HTML page listing recent orders |
+| `POST /Home/Create` | `302` | Redirect to the orders page on success |
+
+Example `GET /ops/info` response:
+
+```json
+{
+  "version": "1.0.0",
+  "region": "koreacentral"
+}
+```
+
+Example `GET /healthz` response:
+
+```json
+{
+  "status": "Healthy"
+}
+```
+
+## SQL connectivity
+
+- TCP `1433` on the SQL logical server FQDN is reachable from Azure services.
+- The `sqldb-storefront` database exists and contains the `Products` and `Orders` tables.
+
+## Telemetry
+
+After sending a handful of requests, Application Insights reports request telemetry:
+
+```bash
+az monitor app-insights metrics show \
+  --app <appInsightsName> \
+  --resource-group rg-practical-storefront-stage01 \
+  --metric requests/count \
+  --interval PT5M
+```
+
+Expected: the `value` field is greater than `0`.
+
+## Teardown
+
+```bash
+az group delete --name rg-practical-storefront-stage01 --yes --no-wait
+```
+
+Expected: exit code `0`. Within a few minutes `az group show` for the resource group returns "not found".
+
+## Related
+
+- [Deployment checklist](checklist.md)
+- [Sample requests](sample-requests.http)
+- [Stage 1 — MVP walkthrough](../../../docs/practical-journey/stage-01-mvp.md)

--- a/labs/trunk/stage-01-mvp/sample-requests.http
+++ b/labs/trunk/stage-01-mvp/sample-requests.http
@@ -1,0 +1,27 @@
+@webAppUrl = https://REPLACE-WITH-YOUR-WEBAPP.azurewebsites.net
+
+### Catalog home page (expect 200, HTML)
+GET {{webAppUrl}}/
+Accept: text/html
+
+### Health check (expect 200, {"status":"Healthy"})
+GET {{webAppUrl}}/healthz
+Accept: application/json
+
+### Ops info (expect 200, JSON with version and region)
+GET {{webAppUrl}}/ops/info
+Accept: application/json
+
+### Ops version (expect 200, JSON with version)
+GET {{webAppUrl}}/ops/version
+Accept: application/json
+
+### Recent orders (expect 200, HTML)
+GET {{webAppUrl}}/Home/Orders
+Accept: text/html
+
+### Create an order (expect 302 redirect on success)
+POST {{webAppUrl}}/Home/Create
+Content-Type: application/x-www-form-urlencoded
+
+ProductId=1&Quantity=2&CustomerName=Demo+User

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,6 +211,8 @@ nav:
     - design-labs/lab-01-public-web-baseline.md
     - design-labs/lab-02-private-internal-app.md
     - design-labs/lab-03-event-driven-orders.md
+  - Practical Journey:
+    - practical-journey/stage-01-mvp.md
   - Reference:
     - reference/index.md
     - reference/architecture-decision-matrix.md

--- a/scripts/practical/common.sh
+++ b/scripts/practical/common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRACTICAL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${PRACTICAL_ROOT}/../.." && pwd)"
+export PRACTICAL_ROOT REPO_ROOT
+
+log()  { printf '\033[0;34m[practical]\033[0m %s\n' "$*"; }
+ok()   { printf '\033[0;32m[ ok ]\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m[warn]\033[0m %s\n' "$*"; }
+err()  { printf '\033[0;31m[fail]\033[0m %s\n' "$*" >&2; }
+
+die() { err "$*"; exit 1; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+load_stage_env() {
+  local stage_id="$1"
+  local env_file="${PRACTICAL_ROOT}/stages/${stage_id}.env"
+  [[ -f "$env_file" ]] || die "Stage env file not found: $env_file"
+  # shellcheck disable=SC1090
+  source "$env_file"
+}
+
+require_azure_login() {
+  require_cmd az
+  az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run: az login"
+}
+
+ensure_resource_group() {
+  local rg="$1" location="$2"
+  if az group show --resource-group "$rg" >/dev/null 2>&1; then
+    log "Resource group '$rg' already exists."
+  else
+    log "Creating resource group '$rg' in '$location'."
+    az group create --resource-group "$rg" --location "$location" --output none
+    ok "Resource group '$rg' created."
+  fi
+}
+
+deployment_output() {
+  local rg="$1" deployment="$2" key="$3"
+  az deployment group show \
+    --resource-group "$rg" \
+    --name "$deployment" \
+    --query "properties.outputs.${key}.value" \
+    --output tsv 2>/dev/null
+}

--- a/scripts/practical/deploy-stage.sh
+++ b/scripts/practical/deploy-stage.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/practical/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+STAGE_ARG="${1:-}"
+[[ -n "$STAGE_ARG" ]] || die "Usage: deploy-stage.sh <stage-id>   e.g. deploy-stage.sh stage-01"
+
+load_stage_env "$STAGE_ARG"
+require_azure_login
+
+[[ -n "${SQL_ADMIN_PASSWORD:-}" ]] || die "SQL_ADMIN_PASSWORD is not set. Export it before deploying."
+
+DEPLOYMENT_NAME="${STAGE_ID}-$(date +%Y%m%d%H%M%S)"
+
+ensure_resource_group "$RG" "$LOCATION"
+
+log "Deploying ${STAGE_TITLE} to resource group '${RG}'."
+az deployment group create \
+  --resource-group "$RG" \
+  --name "$DEPLOYMENT_NAME" \
+  --template-file "${REPO_ROOT}/${TEMPLATE_FILE}" \
+  --parameters "${REPO_ROOT}/${PARAMETERS_FILE}" \
+  --parameters \
+      appBaseName="$APP_BASE_NAME" \
+      location="$LOCATION" \
+      sqlAdministratorLogin="$SQL_ADMIN_LOGIN" \
+      sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD" \
+  --output none
+
+ok "Deployment '${DEPLOYMENT_NAME}' complete."
+
+WEBAPP_URL="$(deployment_output "$RG" "$DEPLOYMENT_NAME" webAppUrl)"
+WEBAPP_NAME="$(deployment_output "$RG" "$DEPLOYMENT_NAME" webAppName)"
+AI_NAME="$(deployment_output "$RG" "$DEPLOYMENT_NAME" appInsightsName)"
+
+log "Web app:        ${WEBAPP_NAME}"
+log "Web app URL:    ${WEBAPP_URL}"
+log "App Insights:   ${AI_NAME}"
+log "Next: scripts/practical/verify-stage.sh ${STAGE_ARG}"
+
+printf '%s\n' "$DEPLOYMENT_NAME" > "${SCRIPT_DIR}/stages/.${STAGE_ID}.last-deployment"

--- a/scripts/practical/destroy-stage.sh
+++ b/scripts/practical/destroy-stage.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/practical/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+STAGE_ARG="${1:-}"
+[[ -n "$STAGE_ARG" ]] || die "Usage: destroy-stage.sh <stage-id>   e.g. destroy-stage.sh stage-01"
+
+load_stage_env "$STAGE_ARG"
+require_azure_login
+
+if ! az group show --resource-group "$RG" >/dev/null 2>&1; then
+  warn "Resource group '${RG}' does not exist. Nothing to destroy."
+  exit 0
+fi
+
+log "Deleting resource group '${RG}' (all ${STAGE_TITLE} resources)."
+az group delete --resource-group "$RG" --yes --no-wait
+ok "Delete requested for '${RG}'. Azure will remove resources in the background."
+
+rm -f "${SCRIPT_DIR}/stages/.${STAGE_ID}.last-deployment"

--- a/scripts/practical/stages/stage-01.env
+++ b/scripts/practical/stages/stage-01.env
@@ -1,0 +1,23 @@
+# Stage 1 — MVP environment configuration.
+# Sourced by scripts/practical/*.sh. Values here are defaults; override via
+# real environment variables before invoking the driver scripts.
+
+STAGE_ID="stage-01"
+STAGE_DIR="stage-01-mvp"
+STAGE_TITLE="Stage 1 — MVP"
+
+# Resource group and region.
+RG="${RG:-rg-practical-storefront-stage01}"
+LOCATION="${LOCATION:-koreacentral}"
+
+# Bicep template and parameters (relative to repo root).
+TEMPLATE_FILE="infra/bicep/stages/stage-01-mvp/main.bicep"
+PARAMETERS_FILE="infra/bicep/stages/stage-01-mvp/main.bicepparam"
+
+# Deployment parameter values passed on the command line.
+APP_BASE_NAME="${APP_BASE_NAME:-storefront}"
+SQL_ADMIN_LOGIN="${SQL_ADMIN_LOGIN:-storefrontadmin}"
+# SQL_ADMIN_PASSWORD must be exported by the caller; never commit a value here.
+
+# Verification smoke tests to run for this stage.
+VERIFY_SCRIPTS=("http-smoke.sh" "sql-smoke.sh")

--- a/scripts/practical/verify-stage.sh
+++ b/scripts/practical/verify-stage.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/practical/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+STAGE_ARG="${1:-}"
+[[ -n "$STAGE_ARG" ]] || die "Usage: verify-stage.sh <stage-id>   e.g. verify-stage.sh stage-01"
+
+load_stage_env "$STAGE_ARG"
+require_azure_login
+
+LAST_DEPLOYMENT_FILE="${SCRIPT_DIR}/stages/.${STAGE_ID}.last-deployment"
+[[ -f "$LAST_DEPLOYMENT_FILE" ]] || die "No recorded deployment for ${STAGE_ID}. Run deploy-stage.sh first."
+DEPLOYMENT_NAME="$(cat "$LAST_DEPLOYMENT_FILE")"
+
+WEBAPP_URL="$(deployment_output "$RG" "$DEPLOYMENT_NAME" webAppUrl)"
+WEBAPP_NAME="$(deployment_output "$RG" "$DEPLOYMENT_NAME" webAppName)"
+SQL_FQDN="$(deployment_output "$RG" "$DEPLOYMENT_NAME" sqlServerFqdn)"
+SQL_DB="$(deployment_output "$RG" "$DEPLOYMENT_NAME" sqlDatabaseName)"
+
+export WEBAPP_URL WEBAPP_NAME SQL_FQDN SQL_DB RG
+
+failures=0
+for smoke in "${VERIFY_SCRIPTS[@]}"; do
+  smoke_path="${SCRIPT_DIR}/verify/${smoke}"
+  [[ -x "$smoke_path" ]] || smoke_path="bash ${SCRIPT_DIR}/verify/${smoke}"
+  log "Running smoke test: ${smoke}"
+  if bash "${SCRIPT_DIR}/verify/${smoke}"; then
+    ok "${smoke} passed."
+  else
+    err "${smoke} failed."
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  die "${failures} smoke test(s) failed for ${STAGE_TITLE}."
+fi
+ok "${STAGE_TITLE} verification passed."

--- a/scripts/practical/verify-stage.sh
+++ b/scripts/practical/verify-stage.sh
@@ -20,7 +20,7 @@ WEBAPP_NAME="$(deployment_output "$RG" "$DEPLOYMENT_NAME" webAppName)"
 SQL_FQDN="$(deployment_output "$RG" "$DEPLOYMENT_NAME" sqlServerFqdn)"
 SQL_DB="$(deployment_output "$RG" "$DEPLOYMENT_NAME" sqlDatabaseName)"
 
-export WEBAPP_URL WEBAPP_NAME SQL_FQDN SQL_DB RG
+export WEBAPP_URL WEBAPP_NAME SQL_FQDN SQL_DB RG SQL_ADMIN_LOGIN
 
 failures=0
 for smoke in "${VERIFY_SCRIPTS[@]}"; do

--- a/scripts/practical/verify/http-smoke.sh
+++ b/scripts/practical/verify/http-smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${WEBAPP_URL:?WEBAPP_URL must be set by verify-stage.sh}"
+
+fail=0
+
+check_status() {
+  local path="$1" expected="$2"
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' "${WEBAPP_URL}${path}")"
+  if [[ "$code" == "$expected" ]]; then
+    printf '[ ok ] GET %-14s -> %s\n' "$path" "$code"
+  else
+    printf '[fail] GET %-14s -> %s (expected %s)\n' "$path" "$code" "$expected" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+check_json_field() {
+  local path="$1" field="$2"
+  local body
+  body="$(curl -s "${WEBAPP_URL}${path}")"
+  if printf '%s' "$body" | grep -q "\"${field}\""; then
+    printf '[ ok ] GET %-14s -> contains "%s"\n' "$path" "$field"
+  else
+    printf '[fail] GET %-14s -> missing "%s" (body: %s)\n' "$path" "$field" "$body" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+check_status "/" "200"
+check_json_field "/healthz" "status"
+check_json_field "/ops/info" "version"
+
+exit "$fail"

--- a/scripts/practical/verify/sql-smoke.sh
+++ b/scripts/practical/verify/sql-smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SQL_FQDN:?SQL_FQDN must be set by verify-stage.sh}"
+: "${SQL_DB:?SQL_DB must be set by verify-stage.sh}"
+
+if [[ -z "${SQL_ADMIN_LOGIN:-}" || -z "${SQL_ADMIN_PASSWORD:-}" ]]; then
+  echo "[warn] SQL_ADMIN_LOGIN/SQL_ADMIN_PASSWORD not set; skipping direct SQL query check." >&2
+fi
+
+if command -v sqlcmd >/dev/null 2>&1 && [[ -n "${SQL_ADMIN_LOGIN:-}" && -n "${SQL_ADMIN_PASSWORD:-}" ]]; then
+  result="$(sqlcmd -S "tcp:${SQL_FQDN},1433" -d "$SQL_DB" \
+    -U "$SQL_ADMIN_LOGIN" -P "$SQL_ADMIN_PASSWORD" \
+    -l 30 -h -1 -W -Q "SELECT COUNT(*) FROM sys.tables;" 2>&1)" || {
+      echo "[fail] sqlcmd query failed: ${result}" >&2
+      exit 1
+    }
+  echo "[ ok ] SQL reachable on ${SQL_FQDN}; user table count: ${result}"
+  exit 0
+fi
+
+if command -v nc >/dev/null 2>&1; then
+  if nc -z -w 10 "$SQL_FQDN" 1433 >/dev/null 2>&1; then
+    echo "[ ok ] TCP 1433 reachable on ${SQL_FQDN} (sqlcmd not installed; connectivity-only check)."
+    exit 0
+  fi
+  echo "[fail] TCP 1433 not reachable on ${SQL_FQDN}." >&2
+  exit 1
+fi
+
+echo "[warn] Neither sqlcmd nor nc available; cannot verify SQL connectivity." >&2
+exit 0


### PR DESCRIPTION
## Summary
Implements **Stage 1 — MVP** of the Practical Journey (issue #15): a public ASP.NET Core web app on App Service backed by Azure SQL Database, with Application Insights telemetry from day one, plus a reusable deploy → verify → destroy script harness.

> Stacked on `feat/foundation-bicep-modules` (PR #68, issue #14) because the Stage 1 orchestrator composes those modules. Rebase onto `main` once #68 merges.

## Details
- **`infra/bicep/stages/stage-01-mvp/`** — `main.bicep` orchestrator composing the #14 foundation modules (Log Analytics 7-day, App Insights, App Service plan Linux **B1**, Web App `DOTNETCORE|8.0`, SQL logical server, SQL DB **Basic**) plus an inline `AllowAllWindowsAzureIps` firewall rule; `main.bicepparam`; `README.md`.
- **`scripts/practical/`** — generic `common.sh`, `deploy-stage.sh`, `verify-stage.sh`, `destroy-stage.sh`; `stages/stage-01.env`; `verify/http-smoke.sh` + `verify/sql-smoke.sh`.
- **`docs/practical-journey/stage-01-mvp.md`** — walkthrough with architecture diagram, pre-reading + deep-dive links, embedded best practices; added to `mkdocs.yml` nav.
- **`labs/trunk/stage-01-mvp/`** — `checklist.md`, `sample-requests.http`, `expected-results.md`.

## Verification
- `az bicep build` on `main.bicep` → 0 errors / 0 warnings.
- `shellcheck` on all 6 scripts → 0 errors / 0 warnings.
- `bash -n` syntax check → all pass.
- `scripts/validate_content_sources.py` → 0 errors.
- `mkdocs build --strict` → builds clean.

## Design notes
- Stage 1 deliberately uses SQL auth + public SQL endpoint for a simple first deploy; documented as **not** a production target. Later stages migrate to managed identity, Key Vault, and private endpoints.

Part of #15