### PR TITLE
feat: install manifest-driven screenshot capture toolkit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install mkdocs-material mkdocs-minify-plugin
+        run: pip install -r requirements-docs.txt
       - name: Build documentation
         run: mkdocs build --strict
       - name: Upload artifact

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install MkDocs build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material mkdocs-minify-plugin
+          pip install -r requirements-docs.txt
 
       - name: Build documentation with strict validation
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,16 @@ Portal screenshots:
 - Use black-box masking only for unavoidable avatar/profile pixels and only with the repository-approved mask color.
 - If a screenshot cannot be visually verified, remove the Markdown reference or disclose the debt explicitly in the PR.
 
+### Manifest-driven capture pipeline
+
+Portal screenshots are managed as **build artifacts driven by a manifest** (`scripts/capture/`), not hand-placed files. Docs reference a screenshot by a **stable ID** via the `shot()` macro, so re-capturing a blade overwrites the same `.webp` and never requires editing markdown.
+
+- Register every capture in `scripts/capture/manifest.yaml` with a stable `id` (equal to the file stem), `file` path under `docs/assets/`, and accurate `alt` text.
+- Reference it in markdown with `[[[ shot("<id>") ]]]` (custom Jinja delimiters `[[[ ]]]` / `[[% %]]` / `[[# #]]`, configured in `mkdocs.yml`, avoid collisions with `{{ }}`).
+- Encode/downscale raw PNGs to WebP with `scripts/capture/optimize_webp.py`; refresh existing captures through `scripts/capture/diff_gate.py` (below `diff_threshold` only `verified` is bumped, image bytes untouched).
+- Screenshots may be committed as WebP produced by this pipeline. When a capture is optimized to WebP, the **final rendered `.webp`** — not only the raw PNG — MUST be visually verified for PII and caption accuracy before merge. A PII or caption defect introduced or hidden by re-encoding is treated the same as one in a raw PNG.
+- See `scripts/capture/README.md` for the full workflow.
+
 ## Microsoft Learn URL Locale
 
 All `learn.microsoft.com` URLs SHOULD use the `en-us` locale prefix.
@@ -664,3 +674,37 @@ type: short description
 ```
 
 Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`
+
+## Merge Policy (AI Agent Rule)
+
+AI agents MAY merge their own pull requests **autonomously**, but ONLY after ALL of the mandatory gates below pass. There is no separate human approval step — passing every gate IS the approval. If any gate cannot be satisfied, the agent MUST stop and hand the PR to the user instead of merging.
+
+### Mandatory merge gates (ALL required)
+
+| # | Gate | How it is verified |
+|---|---|---|
+| 1 | **Oracle review ≥ 90/100** | Submit the final diff to Oracle for quality review. Score must be **90 or higher with no merge-blocking issues**. Any must-fix item is a blocker even at ≥ 90. |
+| 2 | **CI fully green** | Every required GitHub Actions check on the PR head SHA passes. Verify with `gh pr checks <pr> --watch`; do not merge on `pending` or `failure`. |
+| 3 | **Caption ↔ image match** | For every added/changed image referenced from markdown, the caption/alt text MUST accurately describe the actual rendered image. |
+| 4 | **Final-image PII verification** | Every added/changed `.png`/`.webp` referenced from markdown MUST be visually verified (Read/`look_at`) for PII on the **final committed bytes** — zeroed subscription/tenant IDs, no employee identifiers, no black-box masks. WebP re-encodes are re-verified, not assumed from the raw PNG. |
+
+### Merge procedure
+
+1. Confirm gates 1-4 above, in order. Record the Oracle score and the visual-verification result in the PR thread or the final summary.
+2. Merge with **squash-and-merge** only:
+
+    ```bash
+    gh pr merge <pr> --squash --delete-branch
+    ```
+
+3. Never use merge-commit or rebase-merge; squash keeps `main` history linear and collapses fixup commits.
+4. Never bypass a failing or pending gate. Never merge with `--admin` to skip checks.
+
+### When to stop instead of merging
+
+- Oracle score < 90, or any unresolved must-fix.
+- Any CI check failing or still pending.
+- Any referenced image that cannot be visually verified.
+- The PR touches something outside the agent's stated scope.
+
+In these cases, report the blocking gate and hand off to the user.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,15 @@ extra_javascript:
 
 plugins:
   - search
+  - macros:
+      module_name: scripts/capture/mkdocs_macros
+      j2_variable_start_string: "[[["
+      j2_variable_end_string: "]]]"
+      j2_block_start_string: "[[%"
+      j2_block_end_string: "%]]"
+      j2_comment_start_string: "[[#"
+      j2_comment_end_string: "#]]"
+      on_error_fail: true
   - minify:
       minify_html: true
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,5 @@
 mkdocs-material
 mkdocs-minify-plugin
+mkdocs-macros-plugin
 pymdown-extensions
+PyYAML

--- a/scripts/capture/README.md
+++ b/scripts/capture/README.md
@@ -1,0 +1,66 @@
+# Screenshot capture pipeline
+
+Portal screenshots are treated as **build artifacts driven by a manifest**, not
+hand-placed files. Docs reference a screenshot by a **stable ID**; re-capturing a
+blade overwrites the same file and never requires editing markdown.
+
+This is the in-repo pilot. Once proven across a few sections it is intended to be
+extracted into a central `azure-guide-capture-toolkit` and consumed by every
+guide repo.
+
+## Components
+
+| File | Role |
+|---|---|
+| `manifest.yaml` | Single source of truth. One entry per screenshot: stable `id`, `file`, `alt`, `captured`/`verified` dates, `diff_threshold`. |
+| `screenshot_lib.py` | Shared manifest access. Reads via PyYAML (present at docs-build time); writes lazily via ruamel round-trip to preserve comments. |
+| `optimize_webp.py` | Downscales a raw PNG to `meta.target_width` (1440px) and encodes WebP, then stamps `captured`. |
+| `diff_gate.py` | Compares a fresh capture to the committed image. Below `diff_threshold` it leaves the image byte-identical and only bumps `verified`; above it, re-encodes and bumps `captured`. |
+| `mkdocs_macros.py` | Defines the `shot()` macro consumed at build time. |
+| `portal-capture-helpers.js` | (in `scripts/`) Playwright PII text-replacement + avatar masking used during raw capture. |
+
+## Referencing a screenshot in docs
+
+Use the `shot()` macro with the manifest id:
+
+```markdown
+[[[ shot("01-storage-networking-all-networks") ]]]
+```
+
+This renders the correct relative path plus the manifest `alt` text. The macro
+uses custom Jinja delimiters `[[[ ]]]` / `[[% %]]` / `[[# #]]` (configured in
+`mkdocs.yml`) so it never collides with the `{{ }}`, `{% %}`, or `{#anchor}`
+sequences already present across the docs.
+
+## Adding a new screenshot
+
+1. Capture the raw Portal PNG with Playwright + `portal-capture-helpers.js`
+   (see `scripts/portal-capture-helpers.md`).
+2. Add an entry to `manifest.yaml` (new `id` = intended file stem).
+3. Encode and stamp:
+
+    ```bash
+    python3 scripts/capture/optimize_webp.py /path/to/raw.png --id <shot-id>
+    ```
+
+4. Reference it in markdown with `[[[ shot("<shot-id>") ]]]`.
+5. `mkdocs build --strict` to verify it renders.
+
+## Re-capturing (drift refresh)
+
+Feed the fresh raw PNG through the diff gate instead of the optimizer:
+
+```bash
+python3 scripts/capture/diff_gate.py /path/to/fresh.png --id <shot-id>
+```
+
+- **Unchanged** (below threshold): image bytes untouched, only `verified` is
+  bumped — no image churn in git.
+- **Changed** (at/above threshold): image re-encoded, `captured` bumped.
+
+## Requirements
+
+- Docs build: `mkdocs-macros-plugin` (in `requirements-docs.txt`), PyYAML (mkdocs
+  dependency). Never add a top-level `ruamel` import to `screenshot_lib.py` — the
+  docs-build Python may not have it.
+- Capture/CLI: Python with `Pillow` and `ruamel.yaml`; Node + Playwright.

--- a/scripts/capture/diff_gate.py
+++ b/scripts/capture/diff_gate.py
@@ -1,0 +1,89 @@
+"""Perceptual diff gate for re-captures.
+
+Compares a freshly captured PNG against the WebP currently committed for a shot.
+If the fraction of changed pixels is below the shot's `diff_threshold`, the UI is
+considered unchanged: the committed image is left byte-identical and only the
+manifest `verified` date is bumped (no noisy image churn in git). Above the
+threshold, the new capture is encoded and `captured` is stamped.
+
+Usage:
+    python3 scripts/capture/diff_gate.py <fresh.png> --id <shot-id>
+
+Exit codes:
+    0  handled (encoded a first-time capture, skipped as unchanged, or re-encoded)
+    2  shot id not found in the manifest
+
+If the shot exists in the manifest but no committed image is on disk yet, the
+fresh PNG is encoded as the first-time capture (not an error).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+from optimize_webp import encode
+from screenshot_lib import Manifest
+
+
+def changed_fraction(a: Image.Image, b: Image.Image) -> float:
+    a = a.convert("RGB")
+    b = b.convert("RGB")
+    if a.size != b.size:
+        b = b.resize(a.size, Image.LANCZOS)
+    diff = ImageChops.difference(a, b)
+    grayscale = diff.convert("L")
+    mask = grayscale.point(lambda px: 255 if px > 16 else 0)
+    changed = mask.histogram()[255]
+    return changed / (a.width * a.height)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fresh", type=Path, help="Freshly captured PNG")
+    parser.add_argument("--id", required=True, help="Manifest screenshot id")
+    args = parser.parse_args()
+
+    manifest = Manifest()
+    if args.id not in manifest:
+        print(f"unknown id: {args.id}", file=sys.stderr)
+        return 2
+    shot = manifest.get(args.id)
+    today = _dt.date.today().isoformat()
+
+    if not shot.asset_path.exists():
+        size = encode(
+            args.fresh, shot.asset_path, manifest.target_width, manifest.webp_quality
+        )
+        manifest.set_captured(args.id, today)
+        manifest.save()
+        print(f"new capture: {shot.file} ({size / 1024:.0f} KB)")
+        return 0
+
+    fraction = changed_fraction(Image.open(shot.asset_path), Image.open(args.fresh))
+    if fraction < shot.diff_threshold:
+        manifest.set_verified(args.id, today)
+        manifest.save()
+        print(
+            f"unchanged ({fraction:.4%} < {shot.diff_threshold:.2%}): "
+            f"verified={today}, image untouched"
+        )
+        return 0
+
+    size = encode(
+        args.fresh, shot.asset_path, manifest.target_width, manifest.webp_quality
+    )
+    manifest.set_captured(args.id, today)
+    manifest.save()
+    print(
+        f"changed ({fraction:.4%} >= {shot.diff_threshold:.2%}): re-encoded {shot.display_path} ({size / 1024:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture/manifest.yaml
+++ b/scripts/capture/manifest.yaml
@@ -1,0 +1,38 @@
+# Screenshot manifest — single source of truth for Portal captures.
+#
+# Each entry is an immutable stable ID. Markdown references screenshots by ID
+# via the `shot()` macro (see scripts/capture/mkdocs_macros.py), never by path,
+# so re-capturing a blade NEVER requires editing docs.
+#
+# Fields
+#   id             Stable identifier. Equals the file stem. Referenced from docs
+#                  as [[[ shot("id") ]]]. NEVER rename — renaming breaks docs.
+#   file           Path under docs/assets/ (the rendered image, always .webp).
+#   alt            Alt text / accessibility caption. MUST accurately describe
+#                  what the image shows (AGENTS.md visual-verification contract).
+#   page           Portal blade / scene the capture depicts (human-readable).
+#   captured       Date the current image bytes were produced (YYYY-MM-DD).
+#   verified       Date the capture was last confirmed still accurate. Bumped by
+#                  the diff gate even when the image bytes are unchanged.
+#   diff_threshold Fraction (0..1) of changed pixels above which a re-capture is
+#                  treated as a real UI change worth committing. Below it, only
+#                  `verified` is bumped and the image bytes are left untouched.
+#   prereq         Optional. Path to the provisioning script that creates the
+#                  Azure resources needed to reproduce this blade.
+#
+# The diff gate (scripts/capture/diff_gate.py) and the WebP optimizer
+# (scripts/capture/optimize_webp.py) both read/write this file. The mkdocs
+# `shot()` macro reads it at build time.
+#
+# No screenshots are registered yet in this repository. Add entries here as
+# Portal captures are produced; reference them from docs with
+# [[[ shot("<id>") ]]].
+
+meta:
+  version: 1
+  # Target render width in pixels. Captures are 1600px-wide Portal blades;
+  # the optimizer downscales to this width and encodes WebP.
+  target_width: 1440
+  webp_quality: 82
+
+screenshots: []

--- a/scripts/capture/mkdocs_macros.py
+++ b/scripts/capture/mkdocs_macros.py
@@ -1,0 +1,35 @@
+"""mkdocs-macros module exposing the `shot()` macro.
+
+Configured in mkdocs.yml with custom Jinja delimiters `[[[ ]]]` (see the
+`macros` plugin block) so it never collides with the many `{{ ... }}` sequences
+already in the docs (GitHub Actions `${{ }}`, Mermaid hexagon nodes `X{{ }}`).
+
+Docs reference a screenshot by its stable manifest id:
+
+    [[[ shot("01-storage-networking-all-networks") ]]]
+
+which renders the correct relative image path plus alt text, so re-capturing a
+blade never requires editing any markdown.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from screenshot_lib import Manifest
+
+_manifest = Manifest()
+
+
+def define_env(env) -> None:
+    @env.macro
+    def shot(shot_id: str) -> str:
+        entry = _manifest.get(shot_id)
+        src_uri = env.page.file.src_uri
+        depth = src_uri.count("/")
+        prefix = "../" * depth
+        alt = entry.alt.replace("\\", r"\\").replace("]", r"\]").replace("\n", " ")
+        return f"![{alt}]({prefix}assets/{entry.file})"

--- a/scripts/capture/optimize_webp.py
+++ b/scripts/capture/optimize_webp.py
@@ -1,0 +1,56 @@
+"""Downscale a source PNG to the manifest target width and encode WebP.
+
+Usage:
+    python3 scripts/capture/optimize_webp.py <source.png> --id <shot-id>
+
+Writes the .webp next to its manifest `file` path under docs/assets/ and stamps
+`captured`/`verified` on the manifest entry. Intended to run right after a raw
+Playwright capture produces a 1600px-wide PNG.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+from pathlib import Path
+
+from PIL import Image
+
+from screenshot_lib import Manifest
+
+
+def encode(source: Path, dest: Path, target_width: int, quality: int) -> int:
+    image = Image.open(source)
+    if image.mode not in ("RGB", "RGBA"):
+        image = image.convert("RGB")
+    if image.width > target_width:
+        height = round(image.height * target_width / image.width)
+        image = image.resize((target_width, height), Image.LANCZOS)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    image.save(dest, format="WEBP", quality=quality, method=6)
+    return dest.stat().st_size
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="Source PNG to encode")
+    parser.add_argument("--id", required=True, help="Manifest screenshot id")
+    args = parser.parse_args()
+
+    manifest = Manifest()
+    shot = manifest.get(args.id)
+    size = encode(
+        args.source, shot.asset_path, manifest.target_width, manifest.webp_quality
+    )
+    manifest.set_captured(args.id, _dt.date.today().isoformat())
+    manifest.save()
+
+    rel = shot.display_path
+    print(f"wrote {rel} ({size / 1024:.0f} KB)")
+    if size > 200 * 1024:
+        print(f"WARNING: {rel} exceeds 200 KB target")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture/screenshot_lib.py
+++ b/scripts/capture/screenshot_lib.py
@@ -1,0 +1,170 @@
+"""Shared access layer for the screenshot manifest (scripts/capture/manifest.yaml).
+
+Public API for the WebP optimizer, the diff gate, and the mkdocs `shot()` macro.
+Keeping load/save/lookup in one place guarantees all three tools agree on the
+manifest shape and on how an ID maps to a file under docs/assets/.
+
+Reads use PyYAML (a mkdocs dependency, always present at docs-build time). Writes
+lazily use ruamel round-trip to preserve the hand-authored schema comments; that
+path only runs in the capture/CLI environment, never during `mkdocs build`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import yaml
+
+# Roots are env-overridable so the pilot can be lifted into a central toolkit
+# (or tested from another checkout) without editing the module. Defaults keep
+# the in-repo layout working with zero configuration.
+REPO_ROOT = Path(
+    os.environ.get("CAPTURE_REPO_ROOT", Path(__file__).resolve().parents[2])
+).resolve()
+MANIFEST_PATH = Path(
+    os.environ.get(
+        "CAPTURE_MANIFEST", REPO_ROOT / "scripts" / "capture" / "manifest.yaml"
+    )
+).resolve()
+ASSETS_ROOT = Path(
+    os.environ.get("CAPTURE_ASSETS_ROOT", REPO_ROOT / "docs" / "assets")
+).resolve()
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_REQUIRED_FIELDS = ("id", "file", "alt")
+
+
+class ManifestError(ValueError):
+    """Raised when the manifest violates the stable-ID / file-path contract."""
+
+
+class Shot:
+    def __init__(self, raw: dict) -> None:
+        self._raw = raw
+
+    @property
+    def id(self) -> str:
+        return self._raw["id"]
+
+    @property
+    def file(self) -> str:
+        return self._raw["file"]
+
+    @property
+    def alt(self) -> str:
+        return self._raw["alt"]
+
+    @property
+    def diff_threshold(self) -> float:
+        return float(self._raw.get("diff_threshold", 0.02))
+
+    @property
+    def asset_path(self) -> Path:
+        return ASSETS_ROOT / self.file
+
+    @property
+    def display_path(self) -> Path:
+        try:
+            return self.asset_path.relative_to(REPO_ROOT)
+        except ValueError:
+            return self.asset_path
+
+
+class Manifest:
+    def __init__(self, path: Path = MANIFEST_PATH) -> None:
+        self.path = path
+        self._data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        self._index: dict[str, dict] = {}
+        seen_files: dict[str, str] = {}
+        for entry in self._data.get("screenshots", []):
+            self._validate(entry, seen_files)
+            self._index[entry["id"]] = entry
+            seen_files[entry["file"]] = entry["id"]
+        self._pending: dict[str, dict[str, str]] = {}
+
+    def _validate(self, entry: dict, seen_files: dict[str, str]) -> None:
+        for field in _REQUIRED_FIELDS:
+            if not entry.get(field):
+                raise ManifestError(f"Entry {entry.get('id', '?')} missing '{field}'")
+        shot_id, file = entry["id"], entry["file"]
+        if shot_id in self._index:
+            raise ManifestError(f"Duplicate screenshot id: {shot_id}")
+        if file in seen_files:
+            raise ManifestError(
+                f"Duplicate file '{file}' ({shot_id} and {seen_files[file]})"
+            )
+        file_path = Path(file)
+        if file_path.is_absolute() or ".." in file_path.parts:
+            raise ManifestError(
+                f"{shot_id}: file must be relative under docs/assets: {file}"
+            )
+        if file_path.suffix != ".webp":
+            raise ManifestError(
+                f"{shot_id}: file must be .webp, got {file_path.suffix}"
+            )
+        if file_path.stem != shot_id:
+            raise ManifestError(
+                f"{shot_id}: id must equal file stem ({file_path.stem})"
+            )
+        threshold = entry.get("diff_threshold", 0.02)
+        if not isinstance(threshold, (int, float)) or not 0 <= threshold <= 1:
+            raise ManifestError(
+                f"{shot_id}: diff_threshold must be in [0, 1], got {threshold}"
+            )
+        for date_field in ("captured", "verified"):
+            value = entry.get(date_field)
+            if value is not None and not _DATE_RE.match(str(value)):
+                raise ManifestError(
+                    f"{shot_id}: {date_field} must be YYYY-MM-DD, got {value!r}"
+                )
+
+    @property
+    def target_width(self) -> int:
+        return int(self._data.get("meta", {}).get("target_width", 1440))
+
+    @property
+    def webp_quality(self) -> int:
+        return int(self._data.get("meta", {}).get("webp_quality", 82))
+
+    def __contains__(self, shot_id: str) -> bool:
+        return shot_id in self._index
+
+    def __iter__(self):
+        return (Shot(e) for e in self._index.values())
+
+    def get(self, shot_id: str) -> Shot:
+        if shot_id not in self._index:
+            try:
+                where = self.path.relative_to(REPO_ROOT)
+            except ValueError:
+                where = self.path
+            raise KeyError(
+                f"Unknown screenshot id '{shot_id}'. Add it to {where} first."
+            )
+        return Shot(self._index[shot_id])
+
+    def set_verified(self, shot_id: str, date: str) -> None:
+        self._index[shot_id]["verified"] = date
+        self._pending.setdefault(shot_id, {})["verified"] = date
+
+    def set_captured(self, shot_id: str, date: str) -> None:
+        self._index[shot_id]["captured"] = date
+        self._index[shot_id]["verified"] = date
+        self._pending.setdefault(shot_id, {}).update(captured=date, verified=date)
+
+    def save(self) -> None:
+        from ruamel.yaml import YAML
+
+        ryaml = YAML()
+        ryaml.preserve_quotes = True
+        ryaml.width = 4096
+        doc = ryaml.load(self.path.read_text(encoding="utf-8"))
+        for entry in doc.get("screenshots", []):
+            changes = self._pending.get(entry["id"])
+            if changes:
+                entry.update(changes)
+        with self.path.open("w", encoding="utf-8") as handle:
+            ryaml.dump(doc, handle)
+        self._pending.clear()

--- a/scripts/portal-capture-helpers.js
+++ b/scripts/portal-capture-helpers.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const PII_RULES = [
+  {
+    pattern: /(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-f])/gi,
+    replacement: '00000000-0000-0000-0000-000000000000',
+  },
+  {
+    pattern: /\bMCAPS[-A-Za-z0-9_]*\b/g,
+    replacement: 'Visual Studio Enterprise Subscription',
+  },
+  {
+    pattern: /Microsoft\s+Non-Production/gi,
+    replacement: 'Contoso',
+  },
+  {
+    pattern: /\b[A-Za-z0-9._%+-]+@microsoft\.com(?![A-Za-z0-9.-])/gi,
+    replacement: 'user@example.com',
+  },
+  {
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.onmicrosoft\.com(?![A-Za-z0-9.-])/gi,
+    replacement: 'user@example.com',
+  },
+  {
+    pattern: /\b[A-Za-z0-9-]+\.onmicrosoft\.com(?![A-Za-z0-9.-])/gi,
+    replacement: 'contoso.onmicrosoft.com',
+  },
+  {
+    pattern: /\bychoe\b/gi,
+    replacement: 'demouser',
+  },
+  {
+    pattern: /Yeongseon\s+Choe/g,
+    replacement: 'Demo User',
+  },
+  {
+    pattern: /\byeongseon\b/gi,
+    replacement: 'demouser',
+  },
+  {
+    pattern: /\b[0-9A-F]{32,}\b/g,
+    replacement: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  },
+  {
+    pattern: /\b[0-9a-f]{64}\b/g,
+    replacement: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  },
+  {
+    pattern: /\b[0-9a-f]{32}\b/g,
+    replacement: '00000000000000000000000000000000',
+  },
+  {
+    // Public IPv4 (any non-RFC1918). Must run BEFORE the RFC1918 rule so
+    // that the RFC1918 replacement value 10.0.0.0 is never seen by this
+    // rule. Replacement uses RFC 5737 TEST-NET-1 (192.0.2.0/24), the IETF
+    // documentation range for IPv4.
+    pattern: /\b(?!10\.)(?!172\.(?:1[6-9]|2[0-9]|3[01])\.)(?!192\.168\.)(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}\b/g,
+    replacement: '192.0.2.1',
+  },
+  {
+    pattern: /\b(?:10\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])|172\.(?:1[6-9]|2[0-9]|3[01])\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])|192\.168\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))\b/g,
+    replacement: '10.0.0.0',
+  },
+  {
+    // IPv6 (any, including compressed `::`). Placed at the end so it never
+    // sees hex tokens masked by earlier hex-token rules. Replacement uses
+    // RFC 3849 (2001:db8::/32), the IETF documentation range for IPv6.
+    // Known limitations: does not match IPv4-mapped IPv6 (`::ffff:192.0.2.1`)
+    // or zone identifiers (`fe80::1%eth0`) - neither appears in Portal blades.
+    pattern: /(?<![:.a-fA-F0-9])(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?::[0-9a-fA-F]{1,4}){1,6}|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:))(?![:.a-fA-F0-9])/g,
+    replacement: '2001:db8::1',
+  },
+];
+
+const PORTAL_BLUE = '#0078d4';
+
+const ACCOUNT_AVATAR_SELECTORS = [
+  'button[aria-label*="Account menu"]',
+  'button.fxs-menu-account',
+];
+
+const PII_REPLACEMENT_SCRIPT = (() => {
+  const serialized = PII_RULES
+    .map(({ pattern, replacement }) => `{ re: ${pattern.toString()}, val: ${JSON.stringify(replacement)} }`)
+    .join(', ');
+
+  return `(() => {
+    const subs = [${serialized}];
+    let count = 0;
+    const applySubs = (input) => {
+      let out = input;
+      for (const { re, val } of subs) {
+        re.lastIndex = 0;
+        out = out.replace(re, val);
+      }
+      return out;
+    };
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    const nodes = [];
+    let n;
+    while ((n = walker.nextNode())) nodes.push(n);
+    for (const node of nodes) {
+      const orig = node.textContent || '';
+      const next = applySubs(orig);
+      if (next !== orig) {
+        node.textContent = next;
+        count++;
+      }
+    }
+    document.querySelectorAll('[aria-label]').forEach((el) => {
+      const orig = el.getAttribute('aria-label') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('aria-label', next);
+    });
+    document.querySelectorAll('input, textarea').forEach((el) => {
+      const orig = el.value || '';
+      const next = applySubs(orig);
+      if (next !== orig) {
+        el.value = next;
+        count++;
+      }
+    });
+    document.querySelectorAll('[title]').forEach((el) => {
+      const orig = el.getAttribute('title') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('title', next);
+    });
+    return count;
+  })()`;
+})();
+
+async function applyPiiReplacements(page) {
+  const mainFrame = page.mainFrame();
+  let total = await mainFrame.evaluate(PII_REPLACEMENT_SCRIPT);
+  for (const frame of page.frames()) {
+    if (frame === mainFrame) continue;
+    try {
+      total += await frame.evaluate(PII_REPLACEMENT_SCRIPT);
+    } catch (_) {
+      continue;
+    }
+  }
+  return total;
+}
+
+async function resolveAccountAvatarMask(page) {
+  for (const selector of ACCOUNT_AVATAR_SELECTORS) {
+    const locator = page.locator(selector);
+    if ((await locator.count()) > 0) {
+      return locator.first();
+    }
+  }
+  return null;
+}
+
+async function capturePortalScreenshot(page, outputPath, options = {}) {
+  const { fullPage = false, requireAvatarMask = true } = options;
+
+  const replacements = await applyPiiReplacements(page);
+  await page.waitForTimeout(400);
+
+  const avatar = await resolveAccountAvatarMask(page);
+  const masks = avatar ? [avatar] : [];
+
+  if (!avatar && requireAvatarMask) {
+    const message =
+      'capturePortalScreenshot: no Account-avatar element matched any of ' +
+      JSON.stringify(ACCOUNT_AVATAR_SELECTORS) +
+      '. The English-language Portal exposes the primary `aria-label` selector; ' +
+      'a localized Portal may still match the `button.fxs-menu-account` fallback, ' +
+      'but neither is guaranteed if the page is not fully rendered. ' +
+      'Wait for the target blade to settle before capture, or pass ' +
+      '{ requireAvatarMask: false } to override.';
+    throw new Error(message);
+  }
+
+  await page.screenshot({
+    path: outputPath,
+    fullPage,
+    mask: masks,
+    maskColor: PORTAL_BLUE,
+  });
+
+  return { replacements, path: outputPath, avatarMasked: Boolean(avatar) };
+}
+
+module.exports = {
+  PII_RULES,
+  PII_REPLACEMENT_SCRIPT,
+  PORTAL_BLUE,
+  ACCOUNT_AVATAR_SELECTORS,
+  applyPiiReplacements,
+  resolveAccountAvatarMask,
+  capturePortalScreenshot,
+};

--- a/scripts/portal-capture-helpers.md
+++ b/scripts/portal-capture-helpers.md
@@ -1,0 +1,157 @@
+# Portal capture helpers
+
+Reusable PII-masking utilities for Azure Portal screenshots. Used across every
+documentation capture in this repository to keep redactions consistent and to
+avoid leaking real Azure account identifiers into the documentation.
+
+## What it does
+
+- Replaces real identifiers in text nodes, `aria-label`, `title`, and `input`/
+  `textarea` values with documentation-safe placeholders (see
+  [PII Replacement Rules](../AGENTS.md#pii-replacement-rules)).
+- Walks the main frame **and** every nested iframe (Portal blades render
+  inside iframes).
+- Masks only the Account-menu avatar using Playwright's native `mask` option
+  with Portal blue (`#0078d4`), so the masked region blends into the UI
+  instead of leaving a jarring black rectangle.
+- Throws by default if the Account-avatar selector matches nothing (the only
+  visual element the helper cannot rewrite). Pass
+  `{ requireAvatarMask: false }` to override for blades where the top bar is
+  intentionally absent.
+
+## Node.js usage
+
+```javascript
+const { chromium } = require('playwright');
+const { capturePortalScreenshot } = require('./portal-capture-helpers');
+
+const browser = await chromium.launch({ headless: false });
+const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+const page = await context.newPage();
+
+await page.goto(
+  'https://ms.portal.azure.com/#@<tenant>.onmicrosoft.com/resource/' +
+  'subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Web/sites/<app>/appServices'
+);
+
+await capturePortalScreenshot(
+  page,
+  'docs/assets/platform/architecture/01-overview-baseline.png'
+);
+
+await browser.close();
+```
+
+## MCP `browser_run_code_unsafe` usage
+
+The MCP browser tool executes a single async function in an isolated page
+context, so it cannot `require()` this module. Inline the snippet below
+(replace `<OUTPUT_PATH>` per capture). Keep this snippet in lockstep with
+`PII_RULES` in `portal-capture-helpers.js` - any change in one must be
+mirrored in the other and in the [PII Replacement Rules](../AGENTS.md#pii-replacement-rules) table.
+
+```javascript
+async (page) => {
+  const piiScript = `(() => {
+    const subs = [
+      { re: /(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-f])/gi, val: '00000000-0000-0000-0000-000000000000' },
+      { re: /\\bMCAPS[-A-Za-z0-9_]*\\b/g, val: 'Visual Studio Enterprise Subscription' },
+      { re: /Microsoft\\s+Non-Production/gi, val: 'Contoso' },
+      { re: /\\b[A-Za-z0-9._%+-]+@microsoft\\.com(?![A-Za-z0-9.-])/gi, val: 'user@example.com' },
+      { re: /\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.onmicrosoft\\.com(?![A-Za-z0-9.-])/gi, val: 'user@example.com' },
+      { re: /\\b[A-Za-z0-9-]+\\.onmicrosoft\\.com(?![A-Za-z0-9.-])/gi, val: 'contoso.onmicrosoft.com' },
+      { re: /\\bychoe\\b/gi, val: 'demouser' },
+      { re: /Yeongseon\\s+Choe/g, val: 'Demo User' },
+      { re: /\\byeongseon\\b/gi, val: 'demouser' },
+      { re: /\\b[0-9A-F]{32,}\\b/g, val: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+    ];
+    let count = 0;
+    const applySubs = (input) => {
+      let out = input;
+      for (const { re, val } of subs) { re.lastIndex = 0; out = out.replace(re, val); }
+      return out;
+    };
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    const nodes = []; let n; while ((n = walker.nextNode())) nodes.push(n);
+    for (const node of nodes) {
+      const orig = node.textContent || '';
+      const next = applySubs(orig);
+      if (next !== orig) { node.textContent = next; count++; }
+    }
+    document.querySelectorAll('[aria-label]').forEach(el => {
+      const orig = el.getAttribute('aria-label') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('aria-label', next);
+    });
+    document.querySelectorAll('input, textarea').forEach(el => {
+      const orig = el.value || '';
+      const next = applySubs(orig);
+      if (next !== orig) { el.value = next; count++; }
+    });
+    document.querySelectorAll('[title]').forEach(el => {
+      const orig = el.getAttribute('title') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('title', next);
+    });
+    return count;
+  })()`;
+
+  const mainFrame = page.mainFrame();
+  let total = await mainFrame.evaluate(piiScript);
+  for (const frame of page.frames()) {
+    if (frame === mainFrame) continue;
+    try { total += await frame.evaluate(piiScript); } catch (_) {}
+  }
+  await page.waitForTimeout(400);
+
+  const selectors = ['button[aria-label*="Account menu"]', 'button.fxs-menu-account'];
+  let avatar = null;
+  for (const s of selectors) {
+    const loc = page.locator(s);
+    if ((await loc.count()) > 0) { avatar = loc.first(); break; }
+  }
+  if (!avatar) {
+    throw new Error('No Account-avatar element matched ' + JSON.stringify(selectors) + '. Wait for the blade to settle before capture; non-English Portals may still match the fxs-menu-account fallback but that is best-effort, not guaranteed.');
+  }
+
+  await page.screenshot({
+    path: '<OUTPUT_PATH>',
+    fullPage: false,
+    mask: [avatar],
+    maskColor: '#0078d4',
+  });
+
+  return 'replaced ' + total + ' text occurrences';
+};
+```
+
+## Capture workflow rules
+
+- **Re-navigate (`browser_navigate`) between captures.** Portal CSS is
+  cumulative, and leftover styles from a previous capture can leak into the
+  next page (for example, the left-nav rendering as a black box).
+- **Use `ms.portal.azure.com` with the tenant hint fragment** (e.g.
+  `#@<tenant>.onmicrosoft.com/...`). Plain `portal.azure.com` triggers a login
+  redirect.
+- **Prefer the English-language Portal.** The primary avatar selector keys
+  off the English `aria-label` "Account menu". A localized Portal may still
+  match the `button.fxs-menu-account` fallback class, but that fallback is
+  best-effort and not a stable contract. The helper throws if neither
+  selector matches; non-English captures should be reviewed manually.
+- **Close every transient flyout, drawer, and command-bar dropdown** before
+  capture. Account panel, Recent menu, notifications panel, and tenant
+  switcher each surface PII the helper cannot fully rewrite (avatar
+  thumbnails, embedded canvases, late-rendered iframe content).
+- **Wait for the target blade to finish rendering** before applying
+  replacements. The 400 ms post-replacement pause inside the helper is not a
+  substitute for a per-blade `browser_wait_for` against a stable text or
+  element on the blade.
+- **Viewport: 1600 x 1000** captures the standard Portal blade layout without
+  horizontal scrollbars.
+- **No black-box masking.** If a value cannot be rewritten and is not a known
+  avatar/badge, fail the capture and update `PII_RULES` rather than fall back
+  to a black rectangle.
+
+If `PII_RULES` is updated, mirror the change in the
+[PII Replacement Rules](../AGENTS.md#pii-replacement-rules) table and in the
+inline MCP snippet above.


### PR DESCRIPTION
## Summary
- Port the manifest-driven screenshot capture toolkit from the storage guide into this repo, including `scripts/capture/*` and the portal capture helpers, with an empty manifest and no screenshot assets yet.
- Wire MkDocs and docs CI to load the `shot()` macro via `mkdocs-macros-plugin`, shared docs requirements, and the install-from-requirements workflow pattern.
- Mirror the screenshot pipeline and merge-policy conventions in `AGENTS.md`.

## Changed files
- `scripts/capture/README.md`
- `scripts/capture/diff_gate.py`
- `scripts/capture/manifest.yaml`
- `scripts/capture/mkdocs_macros.py`
- `scripts/capture/optimize_webp.py`
- `scripts/capture/screenshot_lib.py`
- `scripts/portal-capture-helpers.js`
- `scripts/portal-capture-helpers.md`
- `mkdocs.yml`
- `requirements-docs.txt`
- `.github/workflows/docs.yml`
- `AGENTS.md`

## Validation
- `pip install -q -r requirements-docs.txt` (via isolated venv due local PEP 668 system Python restriction)
- `mkdocs build --strict` ✅
- Build log shows `Config macros: ['context', 'macros_info', 'now', 'fix_url', 'shot']`