### PR TITLE
docs: add Practical Journey hub pages and nav integration

### DIFF
--- a/docs/practical-journey/cost-and-time-model.md
+++ b/docs/practical-journey/cost-and-time-model.md
@@ -1,0 +1,64 @@
+---
+description: Cost and time model for the Practical Journey — compare the five staged deployments, sum the published estimates, and tear each stage down cleanly.
+---
+
+# Cost and Time Model
+
+Use this page to compare the published budget and deployment window for each Practical Journey stage before you choose which one to run.
+
+## Stage estimates
+
+| Stage | Trigger | Cost | Time |
+|---|---|---|---|
+| [Stage 1 — MVP](stage-01-mvp.md) | "We need a real public web app online this week." | ~$0.09–$0.13/hour | 20–30 min |
+| [Stage 2 — Production Baseline](stage-02-production-baseline.md) | "The app now matters to the business." | ~$0.14–$0.20/hour | 25–40 min |
+| [Stage 3 — Scale / Edge](stage-03-scale-edge.md) | "Traffic is growing and internet exposure is a concern." | ~$0.20–$0.30/hour | 35–50 min |
+| [Stage 4 — Network Isolation](stage-04-network-isolation.md) | "Compliance requires private data access." | ~$0.24–$0.36/hour | 35–55 min |
+| [Stage 5 — Resilience](stage-05-resilience.md) | "Business needs regional outage tolerance." | ~$0.45–$0.80/hour | 50–75 min |
+| **Total (sum of published stage estimates)** | Full sequential walkthrough across all five stages | **~$1.12–$1.79/hour** | **165–250 min** |
+
+## How to read the total
+
+- The **time total** is a straight sum of the five published deployment windows: **165–250 minutes**.
+- The **cost total** is the straight sum of the five published hourly estimates: **~$1.12–$1.79/hour**.
+- In practice, most readers deploy **one stage at a time**, verify it, and destroy it before moving on. In that common flow, your live hourly burn is the cost of the currently running stage, not the sum of all five.
+
+## Choosing the right stage
+
+Use the trigger sentence as the primary selector:
+
+- Pick Stage 1 when delivery speed matters more than production hardening.
+- Pick Stage 2 when secrets, release safety, and alerting can no longer wait.
+- Pick Stage 3 when internet exposure and scale behavior are now production concerns.
+- Pick Stage 4 when the data path must move behind private networking.
+- Pick Stage 5 when regional outage tolerance becomes a real business requirement.
+
+## Destroy instructions
+
+Each stage tears down through the same driver script shape:
+
+```bash
+scripts/practical/destroy-stage.sh stage-01
+scripts/practical/destroy-stage.sh stage-02
+scripts/practical/destroy-stage.sh stage-03
+scripts/practical/destroy-stage.sh stage-04
+scripts/practical/destroy-stage.sh stage-05
+```
+
+The destroy script deletes the stage resource group with `--yes --no-wait`, so Azure removes the resources asynchronously in the background.
+
+## Practical budgeting advice
+
+The stage costs are intentionally progressive: every later stage buys down an additional production risk. Treat the earlier stages as learning and baseline checkpoints, not as sunk cost you must keep running forever.
+
+## See Also
+
+- [Practical Journey](index.md)
+- [Getting Started](getting-started.md)
+- [Verify and Destroy](verify-and-destroy.md)
+- [Stage 5 — Resilience](stage-05-resilience.md)
+
+## Sources
+
+- [Azure pricing](https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/azure-services-costs)
+- [Azure architecture cost optimization guidance](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)

--- a/docs/practical-journey/getting-started.md
+++ b/docs/practical-journey/getting-started.md
@@ -1,0 +1,96 @@
+---
+description: Getting-started guide for the Practical Journey — prerequisites, Azure subscription setup, Azure CLI and Bicep install, and required environment variables.
+---
+
+# Getting Started
+
+Use this page before deploying any Practical Journey stage. It covers the local tools, Azure access, and environment variables that the journey's Bicep templates and driver scripts expect.
+
+## Prerequisites
+
+- Azure CLI installed and authenticated with `az login`.
+- Bicep available through Azure CLI.
+- An Azure subscription where your identity has at least **Contributor** rights on the target resource group or subscription scope.
+- A strong `SQL_ADMIN_PASSWORD` exported in your shell before any stage deployment.
+- For Stage 2 and later, these additional environment variables exported before deployment:
+    - `SQL_ENTRA_ADMIN_LOGIN`
+    - `SQL_ENTRA_ADMIN_OBJECT_ID`
+    - `ALERT_EMAIL_ADDRESS`
+
+## Azure subscription setup
+
+Sign in and confirm the subscription that will hold the stage resources:
+
+```bash
+az login
+az account show --output table
+az account set --subscription <subscription-id-or-name>
+```
+
+If you are unsure whether you can deploy, confirm that your identity can create or update resource groups in the target subscription. The driver scripts call `az group create`, `az deployment group create`, `az group show`, and `az group delete`, so Contributor rights are the practical minimum.
+
+## Install and verify the CLI toolchain
+
+Install or update Bicep through Azure CLI, then confirm both tools respond locally:
+
+```bash
+az bicep install
+az bicep version
+az version
+```
+
+The Practical Journey scripts call `az` directly and the stage parameter files use Bicep features such as `readEnvironmentVariable(...)`, so both Azure CLI and the Bicep CLI integration need to work before deployment.
+
+## Required environment variables
+
+Export the SQL administrator password for every stage:
+
+```bash
+export SQL_ADMIN_PASSWORD='<choose-a-strong-password>'
+```
+
+From Stage 2 onward, export the Microsoft Entra administrator metadata for Azure SQL and the alert notification address as well:
+
+```bash
+export SQL_ENTRA_ADMIN_LOGIN='<entra-user-or-group-display-name>'
+export SQL_ENTRA_ADMIN_OBJECT_ID='<entra-object-id>'
+export ALERT_EMAIL_ADDRESS='<ops-notification-email>'
+```
+
+These values are consumed by the stage parameter files under `infra/bicep/stages/stage-0N-*/main.bicepparam`, which read them from the current shell environment.
+
+## Optional overrides
+
+The stage env files under `scripts/practical/stages/` provide defaults for the resource group, region, app base name, and SQL admin login. Override them only when you need a different naming or location choice:
+
+```bash
+export RG='rg-practical-storefront-stage03'
+export LOCATION='koreacentral'
+export APP_BASE_NAME='storefront'
+export SQL_ADMIN_LOGIN='storefrontadmin'
+```
+
+Stage 5 also has a secondary region in its parameter file. If you need to change it, edit the stage parameter flow deliberately rather than assuming every stage shares the same regional topology.
+
+## Recommended first run
+
+If this is your first pass through the journey:
+
+1. Start with [Stage 1 — MVP](stage-01-mvp.md).
+2. Use [`scripts/practical/deploy-stage.sh`](verify-and-destroy.md) to deploy.
+3. Run the verification flow immediately after deployment.
+4. Tear the stage down before moving to the next one unless you intentionally need it to stay online.
+
+## See Also
+
+- [Practical Journey](index.md)
+- [Cost and Time Model](cost-and-time-model.md)
+- [Verify and Destroy](verify-and-destroy.md)
+- [Stage 1 — MVP](stage-01-mvp.md)
+
+## Sources
+
+- [Install Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [Sign in with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli)
+- [Install Bicep tools](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install)
+- [Azure built-in roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)

--- a/docs/practical-journey/index.md
+++ b/docs/practical-journey/index.md
@@ -1,0 +1,73 @@
+---
+description: Practical Journey hub for the Azure Architecture guide — move from MVP to multi-region resilience through five staged deployments, costs, and verification paths.
+content_sources:
+  diagrams:
+    - id: practical-journey-stage-progression
+      type: flowchart
+      source: self-generated
+      justification: Synthesized from the five Practical Journey stage walkthroughs and their referenced Azure architecture building blocks.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/app-service/overview
+        - https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview
+        - https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview
+        - https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-sql-db
+---
+
+# Practical Journey
+
+The Practical Journey turns the architecture guidance in this repository into a staged deployment path. Each stage is independently deployable, teaches one production concern at a time, and uses the same Practical Storefront sample so you can focus on architecture changes instead of app rewrites.
+
+Use the journey when you want a hands-on progression from a public MVP to a resilient multi-region baseline, with a clear trigger for when each stage becomes worth the extra cost and complexity.
+
+## Journey progression
+
+<!-- diagram-id: practical-journey-stage-progression -->
+```mermaid
+flowchart TD
+    S1[S1 — MVP<br/>Adds App Service, Azure SQL, App Insights, Log Analytics]
+    S2[S2 — Production Baseline<br/>Adds Key Vault, managed identity, staging slot, alerts]
+    S3[S3 — Scale / Edge<br/>Adds Front Door, WAF, autoscale]
+    S4[S4 — Network Isolation<br/>Adds VNet integration, private DNS, SQL private endpoint]
+    S5[S5 — Resilience<br/>Adds secondary region app stack, second SQL server, failover group]
+
+    S1 --> S2 --> S3 --> S4 --> S5
+```
+
+## Stage guide
+
+| Stage | When to use it | Trigger | Cost | Time |
+|---|---|---|---|---|
+| [Stage 1 — MVP](stage-01-mvp.md) | Get a real public app online fast | "We need a real public web app online this week." | ~$0.09–$0.13/hour | 20–30 min |
+| [Stage 2 — Production Baseline](stage-02-production-baseline.md) | Add release safety, secret custody, and alerts | "The app now matters to the business." | ~$0.14–$0.20/hour | 25–40 min |
+| [Stage 3 — Scale / Edge](stage-03-scale-edge.md) | Add edge protection and autoscale | "Traffic is growing and internet exposure is a concern." | ~$0.20–$0.30/hour | 35–50 min |
+| [Stage 4 — Network Isolation](stage-04-network-isolation.md) | Make the data path private | "Compliance requires private data access." | ~$0.24–$0.36/hour | 35–55 min |
+| [Stage 5 — Resilience](stage-05-resilience.md) | Add active-passive regional resilience | "Business needs regional outage tolerance." | ~$0.45–$0.80/hour | 50–75 min |
+
+## How to use the journey
+
+1. Start with [Getting Started](getting-started.md) to prepare your Azure account, CLI tools, and required environment variables.
+2. Use [Cost and Time Model](cost-and-time-model.md) to choose the stage that fits your budget and delivery window.
+3. Deploy only the stage that matches your current production concern. The stages are designed to teach one concern at a time, not to be kept running together by default.
+4. Use [Verify and Destroy](verify-and-destroy.md) after each deployment so the architecture is proven and the spend is cleaned up.
+5. Use [Module Map](module-map.md) when you want to trace a stage back to the Bicep modules that compose it.
+
+## What this section is not
+
+- It is not a single linear lab that must leave all five stages deployed at once.
+- It is not a replacement for the deeper reasoning in Platform, Patterns, and Workload Guides.
+- It does not hide trade-offs: later stages cost more because they solve more production risks.
+
+## See Also
+
+- [Getting Started](getting-started.md)
+- [Cost and Time Model](cost-and-time-model.md)
+- [Module Map](module-map.md)
+- [Verify and Destroy](verify-and-destroy.md)
+- [Public web and API — baseline](../workload-guides/public-web-api/baseline.md)
+
+## Sources
+
+- [Azure App Service overview](https://learn.microsoft.com/en-us/azure/app-service/overview)
+- [Azure Front Door overview](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview)
+- [What is Azure Private Endpoint?](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview)
+- [Auto-failover groups overview and best practices](https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-sql-db)

--- a/docs/practical-journey/index.md
+++ b/docs/practical-journey/index.md
@@ -1,5 +1,5 @@
 ---
-description: Practical Journey hub for the Azure Architecture guide — move from MVP to multi-region resilience through five staged deployments, costs, and verification paths.
+description: Practical Journey hub for the Azure Architecture guide — from MVP to multi-region resilience across five staged deployments, with costs and verification.
 content_sources:
   diagrams:
     - id: practical-journey-stage-progression

--- a/docs/practical-journey/module-map.md
+++ b/docs/practical-journey/module-map.md
@@ -1,0 +1,163 @@
+---
+description: Module map for the Practical Journey — see which Bicep modules each stage uses before moving from MVP to network isolation and resilience.
+content_sources:
+  diagrams:
+    - id: practical-journey-module-stage-map
+      type: flowchart
+      source: self-generated
+      justification: Derived directly from the module references in infra/bicep/stages/stage-01-mvp/main.bicep through stage-05-resilience/main.bicep.
+---
+
+# Module Map
+
+The Practical Journey stages are composed from a shared Bicep module library. This page shows which modules are actually referenced by each stage so you can trace the architecture progression back to reusable infrastructure building blocks.
+
+## Module-to-stage map
+
+<!-- diagram-id: practical-journey-module-stage-map -->
+```mermaid
+flowchart TD
+    subgraph Foundation[Foundation modules]
+        actionGroup[action-group]
+        appInsights[application-insights]
+        autoscale[autoscale-settings]
+        keyVault[key-vault]
+        keyVaultRole[key-vault-role-assignment]
+        logAnalytics[log-analytics-workspace]
+        metricAlerts[metric-alerts]
+        roleAssignment[role-assignment]
+    end
+
+    subgraph Data[Data modules]
+        sqlDatabase[sql-database]
+        sqlFailoverGroup[sql-failover-group]
+        sqlLogicalServer[sql-logical-server]
+    end
+
+    subgraph Network[Network modules]
+        privateDnsZone[private-dns-zone]
+        privateEndpointSql[private-endpoint-sql]
+        privateEndpointWebApp[private-endpoint-webapp]
+        virtualNetwork[virtual-network]
+    end
+
+    subgraph Web[Web modules]
+        appServicePlan[app-service-plan]
+        frontDoorStandard[front-door-standard]
+        webApp[web-app]
+        webAppSlot[web-app-slot]
+    end
+
+    subgraph Stages[Practical Journey stages]
+        S1[S1]
+        S2[S2]
+        S3[S3]
+        S4[S4]
+        S5[S5]
+    end
+
+    logAnalytics --> S1
+    logAnalytics --> S2
+    logAnalytics --> S3
+    logAnalytics --> S4
+    logAnalytics --> S5
+    appInsights --> S1
+    appInsights --> S2
+    appInsights --> S3
+    appInsights --> S4
+    appInsights --> S5
+    appServicePlan --> S1
+    appServicePlan --> S2
+    appServicePlan --> S3
+    appServicePlan --> S4
+    appServicePlan --> S5
+    webApp --> S1
+    webApp --> S2
+    webApp --> S3
+    webApp --> S4
+    webApp --> S5
+    sqlLogicalServer --> S1
+    sqlLogicalServer --> S2
+    sqlLogicalServer --> S3
+    sqlLogicalServer --> S4
+    sqlLogicalServer --> S5
+    sqlDatabase --> S1
+    sqlDatabase --> S2
+    sqlDatabase --> S3
+    sqlDatabase --> S4
+    sqlDatabase --> S5
+    keyVault --> S2
+    keyVault --> S3
+    keyVault --> S4
+    keyVault --> S5
+    keyVaultRole --> S2
+    keyVaultRole --> S3
+    keyVaultRole --> S4
+    keyVaultRole --> S5
+    actionGroup --> S2
+    actionGroup --> S3
+    actionGroup --> S4
+    actionGroup --> S5
+    metricAlerts --> S2
+    metricAlerts --> S3
+    metricAlerts --> S4
+    metricAlerts --> S5
+    webAppSlot --> S2
+    webAppSlot --> S3
+    webAppSlot --> S4
+    webAppSlot --> S5
+    autoscale --> S3
+    autoscale --> S4
+    autoscale --> S5
+    frontDoorStandard --> S3
+    frontDoorStandard --> S4
+    frontDoorStandard --> S5
+    virtualNetwork --> S4
+    privateDnsZone --> S4
+    privateEndpointSql --> S4
+    sqlFailoverGroup --> S5
+```
+
+## Module usage table
+
+| Module category | Module | Stages that reference it |
+|---|---|---|
+| data | `sql-database` | S1, S2, S3, S4, S5 |
+| data | `sql-failover-group` | S5 |
+| data | `sql-logical-server` | S1, S2, S3, S4, S5 |
+| foundation | `action-group` | S2, S3, S4, S5 |
+| foundation | `application-insights` | S1, S2, S3, S4, S5 |
+| foundation | `autoscale-settings` | S3, S4, S5 |
+| foundation | `key-vault` | S2, S3, S4, S5 |
+| foundation | `key-vault-role-assignment` | S2, S3, S4, S5 |
+| foundation | `log-analytics-workspace` | S1, S2, S3, S4, S5 |
+| foundation | `metric-alerts` | S2, S3, S4, S5 |
+| foundation | `role-assignment` | Not referenced by S1-S5 |
+| network | `private-dns-zone` | S4 |
+| network | `private-endpoint-sql` | S4 |
+| network | `private-endpoint-webapp` | Not referenced by S1-S5 |
+| network | `virtual-network` | S4 |
+| web | `app-service-plan` | S1, S2, S3, S4, S5 |
+| web | `front-door-standard` | S3, S4, S5 |
+| web | `web-app` | S1, S2, S3, S4, S5 |
+| web | `web-app-slot` | S2, S3, S4, S5 |
+
+## Reading notes
+
+- Stage 1 uses only the minimum data, foundation, and web modules required for a public baseline.
+- Stage 2 adds the secret, identity, and alerting modules but still keeps SQL public.
+- Stage 3 adds the first edge and scale modules.
+- Stage 4 is the only published stage that references the current network-isolation modules.
+- Stage 5 reuses the Stage 3 public baseline and adds resilience through `sql-failover-group`, not through the Stage 4 private-network modules.
+
+## See Also
+
+- [Practical Journey](index.md)
+- [Verify and Destroy](verify-and-destroy.md)
+- [Stage 4 — Network Isolation](stage-04-network-isolation.md)
+- [Stage 5 — Resilience](stage-05-resilience.md)
+
+## Sources
+
+- [What is Bicep?](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Modules in Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/modules)

--- a/docs/practical-journey/verify-and-destroy.md
+++ b/docs/practical-journey/verify-and-destroy.md
@@ -1,0 +1,114 @@
+---
+description: Verify and destroy the Practical Journey stages with the repo scripts — deploy, smoke-test, record outputs, and remove each stage safely.
+---
+
+# Verify and Destroy
+
+The Practical Journey ships with three generic driver scripts under `scripts/practical/` so every stage follows the same deploy → verify → destroy rhythm.
+
+## Deploy workflow
+
+Deploy a stage by ID:
+
+```bash
+scripts/practical/deploy-stage.sh stage-01
+scripts/practical/deploy-stage.sh stage-02
+scripts/practical/deploy-stage.sh stage-03
+scripts/practical/deploy-stage.sh stage-04
+scripts/practical/deploy-stage.sh stage-05
+```
+
+What `deploy-stage.sh` does:
+
+1. Loads the stage defaults from `scripts/practical/stages/stage-0N.env`.
+2. Verifies that Azure CLI is installed and that `az account show` succeeds.
+3. Requires `SQL_ADMIN_PASSWORD` to already exist in the environment.
+4. Ensures the target resource group exists, creating it with `az group create` when needed.
+5. Runs `az deployment group create` with the stage template, parameter file, and command-line overrides for `appBaseName`, `location`, `sqlAdministratorLogin`, and `sqlAdministratorLoginPassword`.
+6. Prints the deployed web app name, public URL, and Application Insights name.
+7. Records the deployment name in `scripts/practical/stages/.stage-0N.last-deployment` for later verification.
+
+For Stage 2 and later, the stage parameter files also read `SQL_ENTRA_ADMIN_LOGIN`, `SQL_ENTRA_ADMIN_OBJECT_ID`, and `ALERT_EMAIL_ADDRESS` from the current shell environment.
+
+## Verify workflow
+
+Verify the most recent deployment for a stage:
+
+```bash
+scripts/practical/verify-stage.sh stage-01
+scripts/practical/verify-stage.sh stage-02
+scripts/practical/verify-stage.sh stage-03
+scripts/practical/verify-stage.sh stage-04
+scripts/practical/verify-stage.sh stage-05
+```
+
+What `verify-stage.sh` does:
+
+1. Loads the stage env file and checks Azure login.
+2. Reads the recorded deployment name from `scripts/practical/stages/.stage-0N.last-deployment`.
+3. Pulls deployment outputs such as `webAppUrl`, `webAppName`, `sqlServerFqdn`, and `sqlDatabaseName` from the group deployment record.
+4. Exports those values for the smoke-test scripts.
+5. Runs the stage-specific smoke tests listed in `VERIFY_SCRIPTS` inside the matching `stage-0N.env` file.
+6. Fails the stage if any smoke test exits non-zero.
+
+## Smoke tests
+
+| Smoke test | What it checks | Used by |
+|---|---|---|
+| `http-smoke.sh` | `GET /` returns `200`, `/healthz` contains `status`, and `/ops/info` contains `version`. | S1, S2, S3, S4, S5 |
+| `sql-smoke.sh` | If `sqlcmd` and SQL credentials are available, runs `SELECT COUNT(*) FROM sys.tables;` against the target database. Otherwise falls back to a TCP 1433 reachability check with `nc`, or warns if neither tool is available. | S1, S2, S3 |
+| `identity-smoke.sh` | Confirms the web app has a system-assigned identity, looks for a Key Vault and attempts to read `SqlConnectionString` as an operator warning-only check, confirms a SQL Microsoft Entra admin exists, verifies the `staging` slot exists, attempts a slot swap preview/reset, and checks that metric alerts exist. | S2, S3 |
+| `frontdoor-smoke.sh` | Confirms a Front Door profile exists, the endpoint is enabled, a WAF security policy is attached, the origin-group health probe path is `/healthz`, and the autoscale maximum is `2`. An HTTP `200` from the endpoint is treated as best-effort because global propagation can lag. | S3, S4, S5 |
+| `private-connectivity-smoke.sh` | Confirms the SQL server has `publicNetworkAccess` set to `Disabled`, a private endpoint exists and is `Approved`, and the SQL private DNS zone exists with at least one virtual network link. | S4 |
+| `failover-smoke.sh` | Read-only resilience check: confirms at least two web apps across two regions, at least two SQL logical servers, a failover group whose current read-write role is `Primary`, at least one protected database, and a Front Door origin group with two origins using priorities `1` and `2`. | S5 |
+
+## Stage-to-smoke mapping
+
+| Stage | Smoke tests run by `verify-stage.sh` |
+|---|---|
+| Stage 1 | `http-smoke.sh`, `sql-smoke.sh` |
+| Stage 2 | `http-smoke.sh`, `sql-smoke.sh`, `identity-smoke.sh` |
+| Stage 3 | `http-smoke.sh`, `sql-smoke.sh`, `identity-smoke.sh`, `frontdoor-smoke.sh` |
+| Stage 4 | `http-smoke.sh`, `frontdoor-smoke.sh`, `private-connectivity-smoke.sh` |
+| Stage 5 | `http-smoke.sh`, `frontdoor-smoke.sh`, `failover-smoke.sh` |
+
+## Destroy workflow
+
+Destroy a stage by ID:
+
+```bash
+scripts/practical/destroy-stage.sh stage-01
+scripts/practical/destroy-stage.sh stage-02
+scripts/practical/destroy-stage.sh stage-03
+scripts/practical/destroy-stage.sh stage-04
+scripts/practical/destroy-stage.sh stage-05
+```
+
+What `destroy-stage.sh` does:
+
+1. Loads the stage env file and checks Azure login.
+2. Checks whether the target resource group exists.
+3. If the resource group is missing, prints a warning and exits cleanly.
+4. If the resource group exists, runs `az group delete --resource-group <rg> --yes --no-wait`.
+5. Removes the `.stage-0N.last-deployment` marker file so later verification cannot accidentally target a deleted stage.
+
+## Recommended operator sequence
+
+1. Export the required environment variables for the stage you want to run.
+2. Run `scripts/practical/deploy-stage.sh stage-0N`.
+3. Run `scripts/practical/verify-stage.sh stage-0N` immediately after deployment.
+4. Inspect the stage-specific walkthrough page for deeper validation context.
+5. Run `scripts/practical/destroy-stage.sh stage-0N` when you are done.
+
+## See Also
+
+- [Practical Journey](index.md)
+- [Getting Started](getting-started.md)
+- [Cost and Time Model](cost-and-time-model.md)
+- [Module Map](module-map.md)
+
+## Sources
+
+- [Bicep parameter files](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameter-files)
+- [Deploy Bicep files with Azure CLI](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-cli)
+- [Azure resource groups](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-cli)

--- a/docs/start-here/learning-paths.md
+++ b/docs/start-here/learning-paths.md
@@ -54,6 +54,9 @@ Use this page to choose a reading path based on your current architecture expert
 | **Intermediate Architect** | Improve trade-off judgment across patterns and operations | 6-10 hours | Beginner path, then [Patterns Hub](../patterns/index.md) |
 | **Advanced Architect** | Lead reviews, design labs, and portfolio-wide standards | 10-15 hours + ongoing | Intermediate path, then [Design Labs](../design-labs/index.md) |
 
+!!! tip "Want a hands-on companion?"
+    Follow the [Practical Journey](../practical-journey/index.md) for a staged deploy → verify → destroy path that turns the architecture concepts into concrete Azure baselines.
+
 ## Recommended Sequence
 
 <!-- diagram-id: arch-learning-paths-overview -->

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -13,6 +13,8 @@ content_sources:
 
 This guide combines Azure Well-Architected Framework principles, Azure Architecture Center patterns, and practical delivery concerns into a single architecture-first reading path.
 
+If you want a staged hands-on companion to the conceptual material, start with the [Practical Journey](../practical-journey/index.md).
+
 ## What this guide covers
 
 [Documented] Microsoft Learn publishes foundational guidance through the [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/) and the [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/).

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -1,4 +1,5 @@
 ---
+description: Overview of the Azure Architecture practical guide — who it is for, what is in and out of scope, how the sections fit together, and where to begin.
 content_sources:
   diagrams:
     - id: start-here-overview-diagram-1
@@ -109,11 +110,11 @@ flowchart TD
 3. Use workload guides when a team needs a concrete starting baseline.
 4. Use design labs now for guided validation, and use Architecture Reviews once that Phase 2 section is published.
 
-## Microsoft Learn anchors
+## Takeaway
 
-- [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)
-- [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/)
-- [Architecture Center guides](https://learn.microsoft.com/en-us/azure/architecture/guide/)
+[Inferred] Read this repository as a decision system.
+
+Use Microsoft Learn for authoritative product detail, and use this guide for the practical question that teams usually ask first: "which Azure architecture choice should we make, and how will we know it was the right one?"
 
 ## See Also
 
@@ -124,8 +125,8 @@ flowchart TD
 - [Platform Hub](../platform/index.md) — Azure architecture foundations
 - [Well-Architected Framework Hub](../waf/index.md) — pillar-based evaluation
 
-## Takeaway
+## Sources
 
-[Inferred] Read this repository as a decision system.
-
-Use Microsoft Learn for authoritative product detail, and use this guide for the practical question that teams usually ask first: "which Azure architecture choice should we make, and how will we know it was the right one?"
+- [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/)
+- [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/)
+- [Architecture Center guides](https://learn.microsoft.com/en-us/azure/architecture/guide/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,11 @@ nav:
     - design-labs/lab-02-private-internal-app.md
     - design-labs/lab-03-event-driven-orders.md
   - Practical Journey:
+    - practical-journey/index.md
+    - practical-journey/getting-started.md
+    - practical-journey/cost-and-time-model.md
+    - practical-journey/module-map.md
+    - practical-journey/verify-and-destroy.md
     - practical-journey/stage-01-mvp.md
     - practical-journey/stage-02-production-baseline.md
     - practical-journey/stage-03-scale-edge.md

--- a/scripts/validate_mslearn_urls.py
+++ b/scripts/validate_mslearn_urls.py
@@ -59,7 +59,20 @@ def extract_mslearn_urls(frontmatter: dict) -> List[str]:
     urls = set()
 
     content_sources = frontmatter.get("content_sources", {})
-    diagrams = content_sources.get("diagrams", [])
+
+    # content_sources may be the canonical dict form ({"diagrams": [...]}) or a
+    # legacy list form ([{type, url}, ...]). Normalize both without crashing.
+    diagrams = []
+    if isinstance(content_sources, dict):
+        diagrams = content_sources.get("diagrams", [])
+    elif isinstance(content_sources, list):
+        for item in content_sources:
+            if isinstance(item, dict):
+                if isinstance(item.get("diagrams"), list):
+                    diagrams.extend(item["diagrams"])
+                url = item.get("url")
+                if url and "learn.microsoft.com" in url:
+                    urls.add(url)
 
     for diagram in diagrams:
         if isinstance(diagram, dict):


### PR DESCRIPTION
## Summary
- Adds the five Practical Journey hub pages required by #20: `index.md` (stage-progression Mermaid `flowchart TD`), `getting-started.md`, `cost-and-time-model.md`, `module-map.md` (module→stage Mermaid map), and `verify-and-destroy.md`.
- Wires the hub pages into `mkdocs.yml` nav ahead of the existing stage pages, and references the Practical Journey from `start-here/overview.md` and `start-here/learning-paths.md`.
- Fixes `scripts/validate_mslearn_urls.py` to handle legacy list-form `content_sources` without crashing (pre-existing bug that broke the push-to-main MS Learn URL validation job).

## Verification
- `mkdocs build --strict` — passes (0 warnings/errors).
- `validate_content_sources.py` — 0 errors (127 files, 121 with mermaid).
- `validate_cli_flags.py`, `validate_mermaid_format.py`, `validate_mermaid_syntax.py`, `validate_pii.py`, `validate_advr_sections.py` — all pass.
- `validate_mslearn_urls.py` — no longer crashes on list-form frontmatter.

## Notes
- Follows AGENTS.md conventions: `description` frontmatter, per-diagram `content_sources`, `## See Also` → `## Sources` tail order, en-us MS Learn URLs, long CLI flags, 4-space nested indentation.
- Existing `stage-*.md` files untouched.

Closes #20