### PR TITLE
docs: align CONTRIBUTING Quick Start with requirements-docs.txt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ For the full contributing guide, please visit our documentation site:
 ## Quick Start
 
 1. Clone the repository
-2. `pip install mkdocs-material mkdocs-minify-plugin`
+2. `pip install -r requirements-docs.txt` to install all documentation dependencies (Material theme, macros plugin, and the capture toolkit required by `mkdocs.yml`)
 3. `mkdocs serve` to preview locally
 4. `mkdocs build --strict` to validate
 5. Submit a Pull Request


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` Quick Start instructed `pip install mkdocs-material mkdocs-minify-plugin`, but `mkdocs.yml` also requires the macros plugin and `azure-guide-capture-toolkit` (declared in `requirements-docs.txt`). A new contributor following the old instructions hits an immediate `mkdocs serve` failure.

This aligns CONTRIBUTING with `requirements-docs.txt`.

## Validation context

Part of a cross-repo re-validation of a 6-item quality review. This CONTRIBUTING/requirements-docs mismatch was found to be valid and identical across all 8 sibling repos that carry a Quick Start pip line (azure-functions has no such line and needs no change). Same fix was already merged in azure-container-apps-practical-guide (#338, Oracle 100/100).