### PR TITLE
docs: reconcile ko/ja/zh READMEs with English structure

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,32 +2,40 @@
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-Azure アーキテクチャを設計、レビュー、運用するための包括的なガイドです。基礎的な設計判断から Well-Architected のトレードオフ、ワークロードのブループリント、アーキテクチャレビューまでを扱います。
+📘 ドキュメントサイト: <https://yeongseon.github.io/azure-architecture-practical-guide/>
+
+[![Docs](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/docs.yml/badge.svg)](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/docs.yml)
+[![CI](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/quality-gates.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+基礎的な設計判断から Well-Architected のトレードオフ、ワークロードのブループリント、アーキテクチャレビューまで — Azure アーキテクチャを設計、レビュー、運用するための包括的なガイドです。
 
 ## 主な内容
 
-| セクション | 説明 |
-|---------|-------------|
-| [ここから開始 (Start Here)](https://yeongseon.github.io/azure-architecture-practical-guide/) | 概要、学習パス、リポジトリマップ、ガイドの使い方 |
-| [プラットフォーム (Platform)](https://yeongseon.github.io/azure-architecture-practical-guide/platform/) | ランディングゾーン、ID、ネットワーク、コンピュート、データ、回復性を含む Azure アーキテクチャ基盤 |
-| [Well-Architected Framework](https://yeongseon.github.io/azure-architecture-practical-guide/waf/) | コスト、セキュリティ、信頼性、性能、運用の優秀性に関するガイダンス |
-| [アーキテクチャパターン (Architecture Patterns)](https://yeongseon.github.io/azure-architecture-practical-guide/patterns/) | 分解、統合、データ、回復性、ネットワーク、セキュリティ、デプロイの実践パターン |
-| [ワークロードガイド (Workload Guides)](https://yeongseon.github.io/azure-architecture-practical-guide/workload-guides/) | パブリック Web、内部アプリ、統合、サーバーレス、マイクロサービス、データ、AI のブループリント |
-| [運用 (Operations)](https://yeongseon.github.io/azure-architecture-practical-guide/operations/) | ADR、IaC、ガバナンスガードレール、可観測性、FinOps、継続性 |
-| [アーキテクチャレビュー (Architecture Reviews)](https://yeongseon.github.io/azure-architecture-practical-guide/architecture-reviews/) | 決定木、エビデンスマップ、最初の 60 分レビュー、アンチパターン、移行プレイブック |
-| [デザインラボ (Design Labs)](https://yeongseon.github.io/azure-architecture-practical-guide/design-labs/) | 一般的な Azure ワークロードシナリオ向けの設計演習 |
-| [リファレンス (Reference)](https://yeongseon.github.io/azure-architecture-practical-guide/reference/) | 判断マトリクス、サービス選定チートシート、マッピング、用語集、検証ステータス |
+| セクション | 説明 | 状態 |
+|---------|-------------|--------|
+| [ここから開始](https://yeongseon.github.io/azure-architecture-practical-guide/) | 概要、学習パス、リポジトリマップ、ガイドの使い方 | Comprehensive |
+| [プラットフォーム](https://yeongseon.github.io/azure-architecture-practical-guide/platform/) | ランディングゾーン、ID、ネットワーク、コンピュート、データ、回復性を含む Azure アーキテクチャ基盤 | Comprehensive |
+| [Well-Architected Framework](https://yeongseon.github.io/azure-architecture-practical-guide/waf/) | 信頼性、セキュリティ、コストの最適化、運用の優秀性、パフォーマンス効率のガイダンス | Comprehensive |
+| [アーキテクチャパターン](https://yeongseon.github.io/azure-architecture-practical-guide/patterns/) | 実証済みの分解、統合、データ、回復性、ネットワーク、セキュリティ、デプロイパターン | Comprehensive |
+| [ワークロードガイド](https://yeongseon.github.io/azure-architecture-practical-guide/workload-guides/) | パブリック Web、内部アプリ、統合、サーバーレス、マイクロサービス、データ、AI ワークロード向けの実践的なブループリント | Comprehensive |
+| [運用](https://yeongseon.github.io/azure-architecture-practical-guide/operations/) | ADR、IaC、ガバナンスガードレール、可観測性、FinOps、継続性の実践 | Comprehensive |
+| [アーキテクチャレビュー](https://yeongseon.github.io/azure-architecture-practical-guide/architecture-reviews/) | 決定木、エビデンスマップ、最初の 60 分レビュー、アンチパターン、移行プレイブック | In progress |
+| [デザインラボ](https://yeongseon.github.io/azure-architecture-practical-guide/design-labs/) | 一般的な Azure ワークロードシナリオ向けのガイド付き設計演習 | Published |
+| [リファレンス](https://yeongseon.github.io/azure-architecture-practical-guide/reference/) | 判断マトリクス、サービス選定チートシート、マッピング、用語集、検証ステータス | Comprehensive |
+
+**状態の凡例**: **Lab-validated** = 包括的な内容 + 再現可能なラボによるガイドの検証済み · **Comprehensive** = セクション全体完了、MSLearn 検証済み、本番環境対応 · **Published** = コアコンテンツ公開済み、拡張中 · **In progress** = 一部コンテンツあり、活発に開発中 · **Planned** = プレースホルダー、コンテンツ未着手
 
 ## クイックスタート
 
 ```bash
-# リポジトリをクローン
 git clone https://github.com/yeongseon/azure-architecture-practical-guide.git
+cd azure-architecture-practical-guide
 
-# MkDocs の依存関係をインストール
-pip install mkdocs-material mkdocs-minify-plugin
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements-docs.txt
 
-# ローカルドキュメントサーバーを起動
 mkdocs serve
 ```
 
@@ -35,7 +43,7 @@ mkdocs serve
 
 ## リファレンスアーキテクチャ
 
-再利用可能なインフラとドキュメントパターンを中心に、リファレンスアーキテクチャとベースライン資産を整理しています：
+リファレンスアーキテクチャとベースライン資産は、再利用可能なインフラストラクチャとドキュメントパターンを中心に構成されています：
 
 - `infra/bicep/` — アーキテクチャベースラインと共有サービス向け Bicep テンプレート
 - `docs/workload-guides/` — ワークロード別アーキテクチャブループリント
@@ -43,11 +51,13 @@ mkdocs serve
 
 ## 貢献
 
-貢献を歓迎します。以下の点を確認してください：
-- すべての CLI の例で長いフラグを使用してください (`-g` ではなく `--resource-group`)
-- 該当するドキュメントには Mermaid ダイアグラムを含めてください
-- すべてのコンテンツは、ソース URL とともに Microsoft Learn を参照してください
-- CLI 出力の例に個人情報 (PII) を含めないでください
+貢献を歓迎します！以下の点については [貢献ガイド](https://yeongseon.github.io/azure-architecture-practical-guide/contributing/) を参照してください：
+
+- リポジトリ構造とコンテンツ構成
+- ドキュメントテンプレートと執筆基準
+- CLI コマンドスタイルと PII ルール
+- ローカル開発環境のセットアップとビルド検証
+- プルリクエストプロセス
 
 ## 関連プロジェクト
 
@@ -56,9 +66,12 @@ mkdocs serve
 | [azure-virtual-machine-practical-guide](https://github.com/yeongseon/azure-virtual-machine-practical-guide) | Azure Virtual Machines 実務ガイド |
 | [azure-networking-practical-guide](https://github.com/yeongseon/azure-networking-practical-guide) | Azure Networking 実務ガイド |
 | [azure-storage-practical-guide](https://github.com/yeongseon/azure-storage-practical-guide) | Azure Storage 実務ガイド |
+| [azure-app-service-practical-guide](https://github.com/yeongseon/azure-app-service-practical-guide) | Azure App Service 実務ガイド |
 | [azure-functions-practical-guide](https://github.com/yeongseon/azure-functions-practical-guide) | Azure Functions 実務ガイド |
-| [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps 実務ガイド |
+| [azure-communication-services-practical-guide](https://github.com/yeongseon/azure-communication-services-practical-guide) | Azure Communication Services 実務ガイド |
+| [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps 実무ガイド |
 | [azure-kubernetes-service-practical-guide](https://github.com/yeongseon/azure-kubernetes-service-practical-guide) | Azure Kubernetes Service (AKS) 実務ガイド |
+| [azure-architecture-practical-guide](https://github.com/yeongseon/azure-architecture-practical-guide) | Azure Architecture 実務ガイド |
 | [azure-monitoring-practical-guide](https://github.com/yeongseon/azure-monitoring-practical-guide) | Azure Monitoring 実務ガイド |
 
 ## 免責事項 (Disclaimer)

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,32 +2,40 @@
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-Azure 아키텍처를 설계, 검토, 운영하기 위한 포괄적인 가이드입니다. 기초 설계 결정부터 Well-Architected 트레이드오프, 워크로드 청사진, 아키텍처 리뷰까지 다룹니다.
+📘 문서 사이트: <https://yeongseon.github.io/azure-architecture-practical-guide/>
+
+[![Docs](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/docs.yml/badge.svg)](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/docs.yml)
+[![CI](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/quality-gates.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+기초 설계 결정부터 Well-Architected 트레이드오프, 워크로드 청사진, 아키텍처 리뷰까지 — Azure 아키텍처를 설계, 검토, 운영하기 위한 포괄적인 가이드입니다.
 
 ## 주요 내용
 
-| 섹션 | 설명 |
-|---------|-------------|
-| [시작하기 (Start Here)](https://yeongseon.github.io/azure-architecture-practical-guide/) | 개요, 학습 경로, 저장소 맵, 가이드 활용 방법 |
-| [플랫폼 (Platform)](https://yeongseon.github.io/azure-architecture-practical-guide/platform/) | 랜딩 존, ID, 네트워크, 컴퓨팅, 데이터, 복원력을 포함한 Azure 아키텍처 기초 |
-| [Well-Architected Framework](https://yeongseon.github.io/azure-architecture-practical-guide/waf/) | 비용, 보안, 안정성, 성능, 운영 우수성 가이드 |
-| [아키텍처 패턴 (Architecture Patterns)](https://yeongseon.github.io/azure-architecture-practical-guide/patterns/) | 분해, 통합, 데이터, 복원력, 네트워킹, 보안, 배포 패턴 |
-| [워크로드 가이드 (Workload Guides)](https://yeongseon.github.io/azure-architecture-practical-guide/workload-guides/) | 퍼블릭 웹, 내부 앱, 통합, 서버리스, 마이크로서비스, 데이터, AI 워크로드 청사진 |
-| [운영 (Operations)](https://yeongseon.github.io/azure-architecture-practical-guide/operations/) | ADR, IaC, 거버넌스 가드레일, 관측성, FinOps, 비즈니스 연속성 |
-| [아키텍처 리뷰 (Architecture Reviews)](https://yeongseon.github.io/azure-architecture-practical-guide/architecture-reviews/) | 의사결정 트리, 증거 맵, 초기 60분 리뷰, 안티패턴, 마이그레이션 플레이북 |
-| [디자인 랩 (Design Labs)](https://yeongseon.github.io/azure-architecture-practical-guide/design-labs/) | 일반적인 Azure 워크로드 시나리오를 위한 설계 실습 |
-| [참조 (Reference)](https://yeongseon.github.io/azure-architecture-practical-guide/reference/) | 의사결정 매트릭스, 서비스 선택 치트시트, 매핑, 용어집, 검증 상태 |
+| 섹션 | 설명 | 상태 |
+|---------|-------------|--------|
+| [시작하기](https://yeongseon.github.io/azure-architecture-practical-guide/) | 개요, 학습 경로, 저장소 맵, 가이드 활용 방법 | Comprehensive |
+| [플랫폼](https://yeongseon.github.io/azure-architecture-practical-guide/platform/) | 랜딩 존, ID, 네트워크, 컴퓨팅, 데이터, 복원력을 포함한 Azure 아키텍처 기초 | Comprehensive |
+| [Well-Architected Framework](https://yeongseon.github.io/azure-architecture-practical-guide/waf/) | 안정성, 보안, 비용 최적화, 운영 우수성, 성능 효율성 가이드 | Comprehensive |
+| [아키텍처 패턴](https://yeongseon.github.io/azure-architecture-practical-guide/patterns/) | 검증된 분해, 통합, 데이터, 복원력, 네트워킹, 보안, 배포 패턴 | Comprehensive |
+| [워크로드 가이드](https://yeongseon.github.io/azure-architecture-practical-guide/workload-guides/) | 퍼블릭 웹, 내부 앱, 통합, 서버리스, 마이크로서비스, 데이터, AI 워크로드를 위한 실무 청사진 | Comprehensive |
+| [운영](https://yeongseon.github.io/azure-architecture-practical-guide/operations/) | ADR, IaC, 거버넌스 가드레일, 관측성, FinOps, 비즈니스 연속성 실무 | Comprehensive |
+| [아키텍처 리뷰](https://yeongseon.github.io/azure-architecture-practical-guide/architecture-reviews/) | 의사결정 트리, 증거 맵, 초기 60분 리뷰, 안티패턴, 마이그레이션 플레이북 | In progress |
+| [디자인 랩](https://yeongseon.github.io/azure-architecture-practical-guide/design-labs/) | 일반적인 Azure 워크로드 시나리오를 위한 가이드형 설계 실습 | Published |
+| [참조](https://yeongseon.github.io/azure-architecture-practical-guide/reference/) | 의사결정 매트릭스, 서비스 선택 치트시트, 매핑, 용어집, 검증 상태 | Comprehensive |
+
+**상태 범례**: **Lab-validated** = 포괄적인 내용 + 재현 가능한 랩으로 가이드 검증 · **Comprehensive** = 전체 섹션 완료, MSLearn 검증 완료, 생산 환경 적용 가능 · **Published** = 핵심 콘텐츠 게시됨, 확장 중 · **In progress** = 일부 콘텐츠 포함, 활발히 개발 중 · **Planned** = 자리 표시자, 콘텐츠 시작 전
 
 ## 빠른 시작
 
 ```bash
-# 저장소 복제
 git clone https://github.com/yeongseon/azure-architecture-practical-guide.git
+cd azure-architecture-practical-guide
 
-# MkDocs 의존성 설치
-pip install mkdocs-material mkdocs-minify-plugin
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements-docs.txt
 
-# 로컬 문서 서버 시작
 mkdocs serve
 ```
 
@@ -35,7 +43,7 @@ mkdocs serve
 
 ## 참조 아키텍처
 
-재사용 가능한 인프라와 문서 패턴을 중심으로 참조 아키텍처와 기준 자산을 구성합니다:
+참조 아키텍처와 기준 자산은 재사용 가능한 인프라 및 문서 패턴을 중심으로 구성됩니다:
 
 - `infra/bicep/` — 아키텍처 기준선과 공유 서비스를 위한 Bicep 템플릿
 - `docs/workload-guides/` — 워크로드별 아키텍처 청사진
@@ -43,11 +51,13 @@ mkdocs serve
 
 ## 기여하기
 
-기여는 언제나 환영합니다. 다음 사항을 준수해 주세요:
-- 모든 CLI 예제에는 긴 플래그를 사용하세요 (`-g` 대신 `--resource-group`)
-- 해당되는 문서에는 Mermaid 다이어그램을 포함하세요
-- 모든 콘텐츠는 출처 URL과 함께 Microsoft Learn을 참조해야 합니다
-- CLI 출력 예제에 개인 식별 정보(PII)를 포함하지 마세요
+기여는 언제나 환영합니다! 다음 사항은 [기여 가이드](https://yeongseon.github.io/azure-architecture-practical-guide/contributing/)를 참조하세요:
+
+- 저장소 구조 및 콘텐츠 구성
+- 문서 템플릿 및 작성 표준
+- CLI 명령 스타일 및 PII 규칙
+- 로컬 개발 환경 설정 및 빌드 검증
+- 풀 리퀘스트 프로세스
 
 ## 관련 프로젝트
 
@@ -56,9 +66,12 @@ mkdocs serve
 | [azure-virtual-machine-practical-guide](https://github.com/yeongseon/azure-virtual-machine-practical-guide) | Azure Virtual Machines 실무 가이드 |
 | [azure-networking-practical-guide](https://github.com/yeongseon/azure-networking-practical-guide) | Azure Networking 실무 가이드 |
 | [azure-storage-practical-guide](https://github.com/yeongseon/azure-storage-practical-guide) | Azure Storage 실무 가이드 |
+| [azure-app-service-practical-guide](https://github.com/yeongseon/azure-app-service-practical-guide) | Azure App Service 실무 가이드 |
 | [azure-functions-practical-guide](https://github.com/yeongseon/azure-functions-practical-guide) | Azure Functions 실무 가이드 |
+| [azure-communication-services-practical-guide](https://github.com/yeongseon/azure-communication-services-practical-guide) | Azure Communication Services 실무 가이드 |
 | [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps 실무 가이드 |
 | [azure-kubernetes-service-practical-guide](https://github.com/yeongseon/azure-kubernetes-service-practical-guide) | Azure Kubernetes Service (AKS) 실무 가이드 |
+| [azure-architecture-practical-guide](https://github.com/yeongseon/azure-architecture-practical-guide) | Azure Architecture 실무 가이드 |
 | [azure-monitoring-practical-guide](https://github.com/yeongseon/azure-monitoring-practical-guide) | Azure Monitoring 실무 가이드 |
 
 ## 면책 조항 (Disclaimer)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,32 +2,40 @@
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-这是一个用于设计、评审和运营 Azure 架构的综合指南，涵盖基础架构决策、Well-Architected 权衡、工作负载蓝图以及架构评审方法。
+📘 文档网站: <https://yeongseon.github.io/azure-architecture-practical-guide/>
+
+[![Docs](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/docs.yml/badge.svg)](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/docs.yml)
+[![CI](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/yeongseon/azure-architecture-practical-guide/actions/workflows/quality-gates.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+这是一个用于设计、评审和运营 Azure 架构的综合指南 — 涵盖从基础决策、Well-Architected 权衡到工作负载蓝图及架构评审的方方面面。
 
 ## 主要内容
 
-| 章节 | 描述 |
-|---------|-------------|
-| [从这里开始 (Start Here)](https://yeongseon.github.io/azure-architecture-practical-guide/) | 概述、学习路径、仓库地图以及如何使用本指南 |
-| [平台 (Platform)](https://yeongseon.github.io/azure-architecture-practical-guide/platform/) | 包括登录区域、身份、网络、计算、数据与弹性的 Azure 架构基础 |
-| [Well-Architected Framework](https://yeongseon.github.io/azure-architecture-practical-guide/waf/) | 成本、安全、可靠性、性能和运营卓越指导 |
-| [架构模式 (Architecture Patterns)](https://yeongseon.github.io/azure-architecture-practical-guide/patterns/) | 拆分、集成、数据、弹性、网络、安全和部署模式 |
-| [工作负载指南 (Workload Guides)](https://yeongseon.github.io/azure-architecture-practical-guide/workload-guides/) | 面向公共 Web、内部应用、集成、无服务器、微服务、数据和 AI 的实践蓝图 |
-| [运营 (Operations)](https://yeongseon.github.io/azure-architecture-practical-guide/operations/) | ADR、IaC、治理护栏、可观测性、FinOps 和业务连续性 |
-| [架构评审 (Architecture Reviews)](https://yeongseon.github.io/azure-architecture-practical-guide/architecture-reviews/) | 决策树、证据图、前 60 分钟评审、反模式和迁移实战手册 |
-| [设计实验室 (Design Labs)](https://yeongseon.github.io/azure-architecture-practical-guide/design-labs/) | 面向常见 Azure 工作负载场景的设计练习 |
-| [参考 (Reference)](https://yeongseon.github.io/azure-architecture-practical-guide/reference/) | 决策矩阵、服务选型速查表、映射、术语表和验证状态 |
+| 章节 | 描述 | 状态 |
+|---------|-------------|--------|
+| [从这里开始](https://yeongseon.github.io/azure-architecture-practical-guide/) | 概述、学习路径、仓库地图以及如何使用本指南 | Comprehensive |
+| [平台](https://yeongseon.github.io/azure-architecture-practical-guide/platform/) | Azure 架构基础，包括登录区域、身份、网络、计算、数据和弹性 | Comprehensive |
+| [Well-Architected Framework](https://yeongseon.github.io/azure-architecture-practical-guide/waf/) | 可靠性、安全、成本优化、运营卓越和性能效率指导 | Comprehensive |
+| [架构模式](https://yeongseon.github.io/azure-architecture-practical-guide/patterns/) | 经过验证的拆分、集成、数据、弹性、网络、安全和部署模式 | Comprehensive |
+| [工作负载指南](https://yeongseon.github.io/azure-architecture-practical-guide/workload-guides/) | 面向公共 Web、内部应用、集成、无服务器、微服务、数据和 AI 工作负载的实践蓝图 | Comprehensive |
+| [运营](https://yeongseon.github.io/azure-architecture-practical-guide/operations/) | ADR、IaC、治理护栏、可观测性、FinOps 和业务连续性实践 | Comprehensive |
+| [架构评审](https://yeongseon.github.io/azure-architecture-practical-guide/architecture-reviews/) | 决策树、证据图、前 60 分钟评审、反模式和迁移实战手册 | In progress |
+| [设计实验室](https://yeongseon.github.io/azure-architecture-practical-guide/design-labs/) | 针对常见 Azure 工作负载场景的引导式设计练习 | Published |
+| [参考](https://yeongseon.github.io/azure-architecture-practical-guide/reference/) | 决策矩阵、服务选型速查表、映射、术语表和验证状态 | Comprehensive |
+
+**状态说明**: **Lab-validated** = 综合内容 + 可复用的实验室验证指南 · **Comprehensive** = 完整章节，经过 MSLearn 验证，生产就绪 · **Published** = 核心内容已就绪，持续扩展中 · **In progress** = 部分内容，正在积极开发中 · **Planned** = 占位符，内容尚未开始
 
 ## 快速入门
 
 ```bash
-# 克隆仓库
 git clone https://github.com/yeongseon/azure-architecture-practical-guide.git
+cd azure-architecture-practical-guide
 
-# 安装 MkDocs 依赖
-pip install mkdocs-material mkdocs-minify-plugin
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements-docs.txt
 
-# 启动本地文档服务器
 mkdocs serve
 ```
 
@@ -35,19 +43,21 @@ mkdocs serve
 
 ## 参考架构
 
-参考架构和基线资产围绕可复用的基础设施与文档模式组织：
+参考架构和基线资产围绕可复用的基础设施和文档模式组织：
 
 - `infra/bicep/` — 用于架构基线和共享服务的 Bicep 模板
-- `docs/workload-guides/` — 按工作负载划分的架构蓝图
+- `docs/workload-guides/` — 工作负载特定的架构蓝图
 - `docs/patterns/` — 可复用的决策与实现模式
 
 ## 贡献
 
-欢迎贡献。请确保：
-- 所有 CLI 示例使用长标记（使用 `--resource-group` 而不是 `-g`）
-- 在适用时为所有文档添加 Mermaid 图表
-- 所有内容参考 Microsoft Learn 并附带源 URL
-- CLI 输出示例中不含个人身份信息 (PII)
+欢迎贡献！请参阅我们的 [贡献指南](https://yeongseon.github.io/azure-architecture-practical-guide/contributing/) 了解：
+
+- 仓库结构和内容组织
+- 文档模板和编写标准
+- CLI 命令风格和 PII 规则
+- 本地开发设置和构建验证
+- 拉取请求流程
 
 ## 相关项目
 
@@ -56,9 +66,12 @@ mkdocs serve
 | [azure-virtual-machine-practical-guide](https://github.com/yeongseon/azure-virtual-machine-practical-guide) | Azure Virtual Machines 实操指南 |
 | [azure-networking-practical-guide](https://github.com/yeongseon/azure-networking-practical-guide) | Azure Networking 实操指南 |
 | [azure-storage-practical-guide](https://github.com/yeongseon/azure-storage-practical-guide) | Azure Storage 实操指南 |
+| [azure-app-service-practical-guide](https://github.com/yeongseon/azure-app-service-practical-guide) | Azure App Service 实操指南 |
 | [azure-functions-practical-guide](https://github.com/yeongseon/azure-functions-practical-guide) | Azure Functions 实操指南 |
+| [azure-communication-services-practical-guide](https://github.com/yeongseon/azure-communication-services-practical-guide) | Azure Communication Services 实操指南 |
 | [azure-container-apps-practical-guide](https://github.com/yeongseon/azure-container-apps-practical-guide) | Azure Container Apps 实操指南 |
 | [azure-kubernetes-service-practical-guide](https://github.com/yeongseon/azure-kubernetes-service-practical-guide) | Azure Kubernetes Service (AKS) 实操指南 |
+| [azure-architecture-practical-guide](https://github.com/yeongseon/azure-architecture-practical-guide) | Azure Architecture 实操指南 |
 | [azure-monitoring-practical-guide](https://github.com/yeongseon/azure-monitoring-practical-guide) | Azure Monitoring 实操指南 |
 
 ## 免责声明 (Disclaimer)


### PR DESCRIPTION
## Summary

Reconcile the Korean, Japanese, and Simplified Chinese READMEs so they are line-exact and structurally identical to the English `README.md`, differing only in translated prose.

- Match line count, heading count, language switcher, badges, and doc-site line
- Add the `Status` column to the "What's Inside" table (status values kept in English)
- Keep Quick Start `bash` code fences byte-identical to English
- Align the Related Projects list (all 10 sibling repos, same order)
- Remove stale content and translated code comments

Applies the same reconciliation already merged in azure-container-apps-practical-guide.