### PR TITLE
docs: add CLI explanation tables and validation gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -203,6 +203,26 @@ jobs:
             exit 1
           fi
 
+  validate-cli-explanations:
+    name: Validate Azure CLI Explanation Tables
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Enforce explanation tables after Azure CLI code fences
+        run: |
+          if ! python scripts/validate_cli_explanations.py; then
+            echo "::error::Azure CLI explanation table validation failed. Add a '| Command | Purpose |' table immediately after each bash az code fence."
+            exit 1
+          fi
+
   validate-advr-sections:
     name: Validate ADVR Sections
     runs-on: ubuntu-latest

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -129,6 +129,12 @@ Brief introduction
 az group create --name $RG --location $LOCATION
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az group create --name $RG --location $LOCATION` | Creates a resource group using readable long flags. |
+| `--name $RG` | Names the resource group to create. |
+| `--location $LOCATION` | Sets the Azure region for the resource group. |
+
 ```text
 # NEVER use short flags in documentation
 az group create -n $RG -l $LOCATION  # ❌ Don't do this

--- a/docs/practical-journey/getting-started.md
+++ b/docs/practical-journey/getting-started.md
@@ -27,6 +27,14 @@ az account show --output table
 az account set --subscription <subscription-id-or-name>
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az login` | Starts interactive browser sign-in to Azure. |
+| `az account show --output table` | Displays the currently active subscription as a formatted table. |
+| `--output table` | Renders the output as a human-readable table instead of JSON. |
+| `az account set --subscription <subscription-id-or-name>` | Selects the subscription that subsequent commands target. |
+| `--subscription <subscription-id-or-name>` | Identifies the subscription to make active, by ID or display name. |
+
 If you are unsure whether you can deploy, confirm that your identity can create or update resource groups in the target subscription. The driver scripts call `az group create`, `az deployment group create`, `az group show`, and `az group delete`, so Contributor rights are the practical minimum.
 
 ## Install and verify the CLI toolchain
@@ -38,6 +46,12 @@ az bicep install
 az bicep version
 az version
 ```
+
+| Command | Purpose |
+|---------|---------|
+| `az bicep install` | Installs the Bicep CLI that Azure CLI uses to compile `.bicep` templates. |
+| `az bicep version` | Prints the installed Bicep CLI version. |
+| `az version` | Prints the Azure CLI core and installed component versions. |
 
 The Practical Journey scripts call `az` directly and the stage parameter files use Bicep features such as `readEnvironmentVariable(...)`, so both Azure CLI and the Bicep CLI integration need to work before deployment.
 

--- a/docs/practical-journey/stage-01-mvp.md
+++ b/docs/practical-journey/stage-01-mvp.md
@@ -82,6 +82,17 @@ az deployment group create \
   --parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az group create --resource-group rg-practical-storefront-stage01 --location koreacentral` | Creates the resource group that holds every Stage 1 resource. |
+| `--resource-group rg-practical-storefront-stage01` | Names the resource group to create. |
+| `--location koreacentral` | Sets the Azure region for the resource group. |
+| `az deployment group create` | Deploys the Bicep template into the resource group. |
+| `--resource-group rg-practical-storefront-stage01` | Targets the resource group that receives the deployment. |
+| `--template-file infra/bicep/stages/stage-01-mvp/main.bicep` | Points to the Bicep template to deploy. |
+| `--parameters infra/bicep/stages/stage-01-mvp/main.bicepparam` | Supplies deployment parameters from the `.bicepparam` file. |
+| `--parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"` | Overrides the SQL administrator password inline from the exported variable. |
+
 ## Verify
 
 ```bash
@@ -102,6 +113,14 @@ az monitor app-insights metrics show \
   --metric requests/count \
   --interval PT5M
 ```
+
+| Command | Purpose |
+|---------|---------|
+| `az monitor app-insights metrics show` | Reads an aggregated metric from the Application Insights resource. |
+| `--app <appInsightsName>` | Identifies the Application Insights component to query. |
+| `--resource-group rg-practical-storefront-stage01` | Locates the Application Insights resource. |
+| `--metric requests/count` | Selects the request-count metric to return. |
+| `--interval PT5M` | Aggregates the metric over 5-minute (ISO-8601) buckets. |
 
 A `value` greater than `0` confirms Application Insights is capturing requests.
 

--- a/docs/practical-journey/stage-02-production-baseline.md
+++ b/docs/practical-journey/stage-02-production-baseline.md
@@ -96,6 +96,17 @@ az deployment group create \
   --parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az group create --resource-group rg-practical-storefront-stage02 --location koreacentral` | Creates the resource group that holds every Stage 2 resource. |
+| `--resource-group rg-practical-storefront-stage02` | Names the resource group to create. |
+| `--location koreacentral` | Sets the Azure region for the resource group. |
+| `az deployment group create` | Deploys the Bicep template into the resource group. |
+| `--resource-group rg-practical-storefront-stage02` | Targets the resource group that receives the deployment. |
+| `--template-file infra/bicep/stages/stage-02-production-baseline/main.bicep` | Points to the Bicep template to deploy. |
+| `--parameters infra/bicep/stages/stage-02-production-baseline/main.bicepparam` | Supplies deployment parameters from the `.bicepparam` file. |
+| `--parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"` | Overrides the SQL administrator password inline from the exported variable. |
+
 ## Verify
 
 ```bash
@@ -117,6 +128,14 @@ az sql server ad-admin list --server-name <sqlServer> --resource-group rg-practi
 az webapp deployment slot list --name <webAppName> --resource-group rg-practical-storefront-stage02 --query "[].name"
 az monitor metrics alert list --resource-group rg-practical-storefront-stage02 --query "[].name"
 ```
+
+| Command | Purpose |
+|---------|---------|
+| `az webapp identity show --name <webAppName> --resource-group rg-practical-storefront-stage02 --query principalId` | Confirms the web app has a managed identity and returns its principal ID. |
+| `az keyvault secret show --vault-name <keyVaultName> --name SqlConnectionString --query id` | Confirms the Key Vault holds the `SqlConnectionString` secret and returns its ID. |
+| `az sql server ad-admin list --server-name <sqlServer> --resource-group rg-practical-storefront-stage02` | Lists the Microsoft Entra administrator configured on the SQL server. |
+| `az webapp deployment slot list --name <webAppName> --resource-group rg-practical-storefront-stage02 --query "[].name"` | Lists the deployment slots, confirming the staging slot exists. |
+| `az monitor metrics alert list --resource-group rg-practical-storefront-stage02 --query "[].name"` | Lists the configured metric alerts by name. |
 
 See [`labs/trunk/stage-02-production-baseline/`](https://github.com/yeongseon/azure-architecture-practical-guide/tree/main/labs/trunk/stage-02-production-baseline) for the full checklist, sample requests, and expected results.
 

--- a/docs/practical-journey/stage-03-scale-edge.md
+++ b/docs/practical-journey/stage-03-scale-edge.md
@@ -101,6 +101,17 @@ az deployment group create \
   --parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az group create --resource-group rg-practical-storefront-stage03 --location koreacentral` | Creates the resource group that holds every Stage 3 resource. |
+| `--resource-group rg-practical-storefront-stage03` | Names the resource group to create. |
+| `--location koreacentral` | Sets the Azure region for the resource group. |
+| `az deployment group create` | Deploys the Bicep template into the resource group. |
+| `--resource-group rg-practical-storefront-stage03` | Targets the resource group that receives the deployment. |
+| `--template-file infra/bicep/stages/stage-03-scale-edge/main.bicep` | Points to the Bicep template to deploy. |
+| `--parameters infra/bicep/stages/stage-03-scale-edge/main.bicepparam` | Supplies deployment parameters from the `.bicepparam` file. |
+| `--parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"` | Overrides the SQL administrator password inline from the exported variable. |
+
 ## Verify
 
 ```bash
@@ -122,6 +133,13 @@ az afd security-policy list --profile-name <afdProfile> --resource-group rg-prac
 az afd origin-group show --profile-name <afdProfile> --origin-group-name og-storefront --resource-group rg-practical-storefront-stage03 --query healthProbeSettings.probePath
 az monitor autoscale show --name <autoscaleName> --resource-group rg-practical-storefront-stage03 --query "profiles[0].capacity.maximum"
 ```
+
+| Command | Purpose |
+|---------|---------|
+| `az afd endpoint show --profile-name <afdProfile> --endpoint-name <afdEndpoint> --resource-group rg-practical-storefront-stage03 --query enabledState` | Returns whether the Front Door endpoint is enabled. |
+| `az afd security-policy list --profile-name <afdProfile> --resource-group rg-practical-storefront-stage03 --query "length(@)"` | Counts the security policies associated with the Front Door profile, confirming a WAF policy is attached. |
+| `az afd origin-group show --profile-name <afdProfile> --origin-group-name og-storefront --resource-group rg-practical-storefront-stage03 --query healthProbeSettings.probePath` | Returns the health-probe path the origin group uses. |
+| `az monitor autoscale show --name <autoscaleName> --resource-group rg-practical-storefront-stage03 --query "profiles[0].capacity.maximum"` | Returns the configured autoscale maximum instance count. |
 
 See [`labs/trunk/stage-03-scale-edge/`](https://github.com/yeongseon/azure-architecture-practical-guide/tree/main/labs/trunk/stage-03-scale-edge) for the full checklist, sample requests, and expected results.
 

--- a/docs/practical-journey/stage-04-network-isolation.md
+++ b/docs/practical-journey/stage-04-network-isolation.md
@@ -99,6 +99,17 @@ az deployment group create \
   --parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az group create --resource-group rg-practical-storefront-stage04 --location koreacentral` | Creates the resource group that holds every Stage 4 resource. |
+| `--resource-group rg-practical-storefront-stage04` | Names the resource group to create. |
+| `--location koreacentral` | Sets the Azure region for the resource group. |
+| `az deployment group create` | Deploys the Bicep template into the resource group. |
+| `--resource-group rg-practical-storefront-stage04` | Targets the resource group that receives the deployment. |
+| `--template-file infra/bicep/stages/stage-04-network-isolation/main.bicep` | Points to the Bicep template to deploy. |
+| `--parameters infra/bicep/stages/stage-04-network-isolation/main.bicepparam` | Supplies deployment parameters from the `.bicepparam` file. |
+| `--parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"` | Overrides the SQL administrator password inline from the exported variable. |
+
 ## Verify
 
 ```bash
@@ -120,6 +131,12 @@ az sql server show --name <sqlServer> --resource-group rg-practical-storefront-s
 az network private-endpoint show --name <sqlPrivateEndpoint> --resource-group rg-practical-storefront-stage04 --query "privateLinkServiceConnections[0].privateLinkServiceConnectionState.status"
 az network private-dns zone show --name privatelink.database.windows.net --resource-group rg-practical-storefront-stage04 --query name
 ```
+
+| Command | Purpose |
+|---------|---------|
+| `az sql server show --name <sqlServer> --resource-group rg-practical-storefront-stage04 --query publicNetworkAccess` | Returns whether the SQL server's public network access is disabled. |
+| `az network private-endpoint show --name <sqlPrivateEndpoint> --resource-group rg-practical-storefront-stage04 --query "privateLinkServiceConnections[0].privateLinkServiceConnectionState.status"` | Returns the approval status of the SQL private endpoint connection. |
+| `az network private-dns zone show --name privatelink.database.windows.net --resource-group rg-practical-storefront-stage04 --query name` | Confirms the private DNS zone for SQL exists and returns its name. |
 
 To confirm the app actually resolves SQL privately, open the App Service SSH/Kudu console and run `nslookup <sqlServer>.database.windows.net`; it should resolve to a `10.x.x.x` address in the private-endpoint subnet.
 

--- a/docs/practical-journey/stage-05-resilience.md
+++ b/docs/practical-journey/stage-05-resilience.md
@@ -102,6 +102,17 @@ az deployment group create \
   --parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az group create --resource-group rg-practical-storefront-stage05 --location koreacentral` | Creates the resource group that holds every Stage 5 resource. |
+| `--resource-group rg-practical-storefront-stage05` | Names the resource group to create. |
+| `--location koreacentral` | Sets the Azure region for the resource group. |
+| `az deployment group create` | Deploys the Bicep template into the resource group. |
+| `--resource-group rg-practical-storefront-stage05` | Targets the resource group that receives the deployment. |
+| `--template-file infra/bicep/stages/stage-05-resilience/main.bicep` | Points to the Bicep template to deploy. |
+| `--parameters infra/bicep/stages/stage-05-resilience/main.bicepparam` | Supplies deployment parameters from the `.bicepparam` file. |
+| `--parameters sqlAdministratorLoginPassword="$SQL_ADMIN_PASSWORD"` | Overrides the SQL administrator password inline from the exported variable. |
+
 ## Verify
 
 ```bash
@@ -132,6 +143,13 @@ sleep 120
 curl -s "https://${FRONTDOOR}/ops/info"
 ```
 
+| Command | Purpose |
+|---------|---------|
+| `az afd endpoint list --profile-name <profile> --resource-group "$RG" --query '[0].hostName' --output tsv` | Returns the Front Door endpoint hostname as plain text for use in a shell variable. |
+| `az afd profile list --resource-group "$RG" --query '[0].name' --output tsv` | Returns the Front Door profile name as plain text, used to look up the endpoint. |
+| `--output tsv` | Emits a plain tab-separated value with no quoting, suitable for shell variable capture. |
+| `az webapp stop --name <primaryWebApp> --resource-group "$RG"` | Stops the primary region's web app to simulate a regional outage. |
+
 After the primary stops and Front Door's health probe (30s interval, 3 of 4 samples) fails it out of rotation — typically within 1–2 minutes — `/ops/info` reports `"region": "secondary"` — user traffic has failed over at the **app tier** while the database read-write role is still in the primary region. To fail the **data tier** over as well:
 
 ```bash
@@ -139,6 +157,11 @@ az sql failover-group set-primary --name <failoverGroup> --server <secondarySqlS
 
 az sql failover-group show --name <failoverGroup> --server <secondarySqlServer> --resource-group "$RG" --query replicationRole
 ```
+
+| Command | Purpose |
+|---------|---------|
+| `az sql failover-group set-primary --name <failoverGroup> --server <secondarySqlServer> --resource-group "$RG"` | Promotes the secondary SQL server to the read-write primary role, failing the data tier over. |
+| `az sql failover-group show --name <failoverGroup> --server <secondarySqlServer> --resource-group "$RG" --query replicationRole` | Returns the replication role of the specified server to confirm the failover completed. |
 
 The role now reports `Primary` on the secondary server. Fail back by starting the primary app and running `set-primary` against the primary server again.
 

--- a/scripts/validate_cli_explanations.py
+++ b/scripts/validate_cli_explanations.py
@@ -50,24 +50,54 @@ def fence_language(line: str) -> str:
     return info.split(maxsplit=1)[0] if info else ""
 
 
+def _table_cells(line: str) -> list[str]:
+    """Split a Markdown table row into trimmed, lower-cased cell values.
+
+    Leading and trailing pipes produce empty edge cells, which are dropped.
+
+    >>> _table_cells("| Command | Purpose |")
+    ['command', 'purpose']
+    >>> _table_cells("|Name|Value|")
+    ['name', 'value']
+    """
+    return [cell.strip().lower() for cell in line.strip().strip("|").split("|")]
+
+
 def has_following_table(lines: list[str], start_index: int) -> bool:
-    """Return True when a Markdown table appears shortly after a fence."""
-    checked = 0
+    """Return True when the house `| Command | Purpose |` table immediately
+    follows a fence.
+
+    "Immediately" allows only blank lines between the closing fence and the
+    table header. Any intervening prose, heading, admonition, or a differently
+    headed table fails the check, so the CI gate enforces the documented
+    convention rather than accepting any nearby Markdown table.
+
+    >>> src = ["", "| Command | Purpose |", "|---------|---------|", "| az x | y |"]
+    >>> has_following_table(src, 0)
+    True
+    >>> no_blank = ["| Command | Purpose |", "|---|---|"]
+    >>> has_following_table(no_blank, 0)
+    True
+    >>> wrong_header = ["", "| Name | Value |", "|------|-------|"]
+    >>> has_following_table(wrong_header, 0)
+    False
+    >>> prose_first = ["", "This explains the command.", "| Command | Purpose |", "|---|---|"]
+    >>> has_following_table(prose_first, 0)
+    False
+    >>> missing_separator = ["| Command | Purpose |", "| az x | y |"]
+    >>> has_following_table(missing_separator, 0)
+    False
+    """
     i = start_index
-    while i < len(lines) and checked < 8:
-        stripped = lines[i].strip()
-        if not stripped:
-            i += 1
-            checked += 1
-            continue
-        if stripped.startswith(("!!!", "???", "##", "```")):
-            return False
-        if stripped.startswith("|") and i + 1 < len(lines):
-            next_line = lines[i + 1].strip()
-            return next_line.startswith("|") and "---" in next_line
+    while i < len(lines) and not lines[i].strip():
         i += 1
-        checked += 1
-    return False
+    if i + 1 >= len(lines):
+        return False
+    header_cells = _table_cells(lines[i])
+    if header_cells != ["command", "purpose"]:
+        return False
+    separator = lines[i + 1].strip()
+    return separator.startswith("|") and "---" in separator
 
 
 def validate_file(path: Path) -> list[Finding]:

--- a/scripts/validate_cli_explanations.py
+++ b/scripts/validate_cli_explanations.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate that Azure CLI code fences have nearby explanation tables."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+AZ_PATTERN = re.compile(r"(^|[^A-Za-z0-9_-])az\s+[A-Za-z0-9_-]")
+FENCE_PATTERN = re.compile(r"^(\s*)```")
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    message: str
+
+
+def has_az_command(block: list[str]) -> bool:
+    return any(AZ_PATTERN.search(line) for line in block)
+
+
+def fence_language(line: str) -> str:
+    """Return the language token from a fence opener like '```bash {.copy}'.
+
+    Handles fences of arbitrary length (```, ````, `````, ...) by
+    stripping all leading backticks before parsing the language token.
+    Returns an empty string for closing fences or unlabeled fences.
+
+    >>> fence_language("```bash")
+    'bash'
+    >>> fence_language("```bash {.copy}")
+    'bash'
+    >>> fence_language("    ```python")
+    'python'
+    >>> fence_language("````bash")
+    'bash'
+    >>> fence_language("`````bash")
+    'bash'
+    >>> fence_language("```")
+    ''
+    >>> fence_language("````")
+    ''
+    """
+    info = line.strip().lstrip("`").strip()
+    return info.split(maxsplit=1)[0] if info else ""
+
+
+def has_following_table(lines: list[str], start_index: int) -> bool:
+    """Return True when a Markdown table appears shortly after a fence."""
+    checked = 0
+    i = start_index
+    while i < len(lines) and checked < 8:
+        stripped = lines[i].strip()
+        if not stripped:
+            i += 1
+            checked += 1
+            continue
+        if stripped.startswith(("!!!", "???", "##", "```")):
+            return False
+        if stripped.startswith("|") and i + 1 < len(lines):
+            next_line = lines[i + 1].strip()
+            return next_line.startswith("|") and "---" in next_line
+        i += 1
+        checked += 1
+    return False
+
+
+def validate_file(path: Path) -> list[Finding]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    findings: list[Finding] = []
+    in_fence = False
+    fence_indent = ""
+    block_start = 0
+    block_lines: list[str] = []
+
+    for index, line in enumerate(lines):
+        fence = FENCE_PATTERN.match(line)
+        if not in_fence and fence:
+            # Only track ```bash fences. Other languages (mermaid, text, json,
+            # kusto, etc.) may legitimately contain `az ...` text in diagram
+            # labels or console-output transcripts, and do not need an
+            # explanation table per AGENTS.md ("Shell: Use bash for all CLI
+            # examples").
+            if fence_language(line) != "bash":
+                continue
+            in_fence = True
+            fence_indent = fence.group(1)
+            block_start = index + 1
+            block_lines = []
+            continue
+
+        if in_fence and fence and len(fence.group(1)) <= len(fence_indent):
+            if has_az_command(block_lines) and not has_following_table(
+                lines, index + 1
+            ):
+                findings.append(
+                    Finding(
+                        path=path,
+                        line=block_start,
+                        message="Azure CLI code fence is missing a following explanation table.",
+                    )
+                )
+            in_fence = False
+            fence_indent = ""
+            block_lines = []
+            continue
+
+        if in_fence:
+            block_lines.append(line)
+
+    return findings
+
+
+def validate_docs(docs_dir: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in sorted(docs_dir.glob("**/*.md")):
+        findings.extend(validate_file(path))
+    return findings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docs-dir", type=Path, default=Path("docs"))
+    args = parser.parse_args()
+
+    findings = validate_docs(args.docs_dir)
+    if findings:
+        for finding in findings:
+            print(f"{finding.path}:{finding.line}: {finding.message}")
+        raise SystemExit(
+            f"{len(findings)} Azure CLI code fence(s) need explanation tables."
+        )
+
+    print("All Azure CLI code fences have following explanation tables.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #84.

Adds per-command explanation tables to every Azure CLI code fence in the Practical Journey and Contributing docs, and wires a CI gate that enforces the convention going forward. This ports the CLI-explanation-table standard already adopted in the sibling Azure App Service guide into this repository.

## Changes

- **New validator** `scripts/validate_cli_explanations.py` (stdlib-only, self-contained): flags any ```` ```bash ```` fence containing `az ...` that is not immediately followed by a Markdown explanation table.
- **CI wiring**: new `validate-cli-explanations` job in `.github/workflows/quality-gates.yml`, mirroring the existing `validate-cli-flags` job.
- **12 explanation tables** added across the 14 flagged fences (2 were added in an earlier commit on this branch):
    - `docs/practical-journey/getting-started.md`
    - `docs/practical-journey/stage-01-mvp.md` … `stage-05-resilience.md`
    - `docs/contributing/index.md`

Each table uses the house `| Command | Purpose |` style: the first row is the full command verbatim, followed by one row per flag with an accurate, command-specific description (no generic filler).

## Verification

- `python3 scripts/validate_cli_explanations.py` → **0 findings**
- `python3 scripts/validate_cli_flags.py` → pass (long flags only)
- `python3 scripts/validate_pii.py` → 0 matches
- `python3 scripts/validate_mermaid_format.py` → 0 errors
- `mkdocs build --strict` → pass
- Diff is **insert-only** (0 deletions in content files); no existing prose or code was modified.