### PR TITLE
Harden CLI explanation table validator: require blank-line termination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,6 +496,42 @@ az group create --name $RG --location $LOCATION
 az group create -n $RG -l $LOCATION  # ❌ Don't do this
 ```
 
+### CLI Explanation Table Rule (Quality Gate)
+
+Every `bash` code fence that contains an `az ...` command MUST be immediately followed by a `| Command | Purpose |` explanation table listing the base command plus every long flag used, one row each. This is enforced by `scripts/validate_cli_explanations.py` (wired into the `Validate CLI Explanation Tables` CI job).
+
+**MANDATORY: the explanation table MUST be terminated by a blank line** (or end-of-file). A table that directly abuts the following line — `Example output:`, a `` ``` `` code fence, or any prose — is a **rendering defect**, not a cosmetic one.
+
+Why this is mandatory, and why generic gates miss it:
+
+- Python-Markdown's `tables` extension is block-level: it requires a blank line **after** the table. Without it, the first following non-blank line is silently absorbed **into the table as a phantom row** (e.g. `Example output:` renders as `<td>Example output:</td><td></td>`), corrupting both the table and the following block.
+- **`mkdocs build --strict` does NOT catch this.** Strict mode fails only on broken links and nav warnings; a malformed-but-parseable table still "builds" clean. A green strict build is therefore **not** evidence that tables render correctly.
+- **Source-only review (including Oracle text review) does NOT catch this.** Reviewing the Markdown source (which looks fine line-by-line) cannot reveal a rendering-level absorption bug. Rendered-HTML verification is required.
+- A table-existence check is insufficient: a validator that only asserts "a table follows the fence" will pass a table missing its trailing blank line. The validator MUST also assert table **termination** (blank line or EOF). `find_unterminated_tables()` in `scripts/validate_cli_explanations.py` enforces this, and its doctests are the executable spec.
+
+Correct:
+
+```markdown
+| Command | Purpose |
+| --- | --- |
+| `az group create` | Create a resource group. |
+| `--name` | Name of the resource group. |
+
+Example output:
+```
+
+Broken (no blank line — `Example output:` is absorbed as a phantom table row):
+
+```markdown
+| Command | Purpose |
+| --- | --- |
+| `az group create` | Create a resource group. |
+| `--name` | Name of the resource group. |
+Example output:
+```
+
+When generating or inserting explanation tables in bulk, always re-verify with the validator **and** spot-check the rendered HTML. Any scanner MUST skip fenced code regions, because KQL blocks use line-leading `|` (`| where`, `| summarize`) that would otherwise be miscounted as table rows — causing both false positives and missed real defects.
+
 ### Variable Naming Convention
 
 | Variable | Description | Example |

--- a/scripts/validate_cli_explanations.py
+++ b/scripts/validate_cli_explanations.py
@@ -100,9 +100,62 @@ def has_following_table(lines: list[str], start_index: int) -> bool:
     return separator.startswith("|") and "---" in separator
 
 
+def find_unterminated_tables(lines: list[str]) -> list[int]:
+    """Return the 1-based line numbers where a house `| Command | Purpose |`
+    table is immediately followed by a non-blank line.
+
+    python-markdown's ``tables`` extension treats the first non-blank line after
+    a table as another table row (a phantom ``<td>...</td>`` cell) unless a blank
+    line terminates the table. Fenced code regions are tracked so that pipe-led
+    lines inside ```` ```kusto ```` blocks (``| where``, ``| summarize``) are not
+    mistaken for table rows.
+
+    >>> ok = ["| Command | Purpose |", "| --- | --- |", "| `az x` | y |", "", "next"]
+    >>> find_unterminated_tables(ok)
+    []
+    >>> bad = ["| Command | Purpose |", "| --- | --- |", "| `az x` | y |", "Example output:"]
+    >>> find_unterminated_tables(bad)
+    [4]
+    >>> eof = ["| Command | Purpose |", "| --- | --- |", "| `az x` | y |"]
+    >>> find_unterminated_tables(eof)
+    []
+    >>> kql = ["```kusto", "AzureActivity", "| where x == 1", "```", "prose"]
+    >>> find_unterminated_tables(kql)
+    []
+    """
+    hits: list[int] = []
+    i = 0
+    n = len(lines)
+    in_fence = False
+    while i < n:
+        if FENCE_PATTERN.match(lines[i]):
+            in_fence = not in_fence
+            i += 1
+            continue
+        if not in_fence and _table_cells(lines[i]) == ["command", "purpose"]:
+            j = i
+            while j < n and lines[j].lstrip().startswith("|"):
+                j += 1
+            if j < n and lines[j].strip() != "":
+                hits.append(j + 1)
+            i = j
+            continue
+        i += 1
+    return hits
+
+
 def validate_file(path: Path) -> list[Finding]:
     lines = path.read_text(encoding="utf-8").splitlines()
     findings: list[Finding] = []
+    for line_no in find_unterminated_tables(lines):
+        findings.append(
+            Finding(
+                path=path,
+                line=line_no,
+                message="Explanation table must be followed by a blank line "
+                "(otherwise the next line is absorbed as a phantom table row).",
+            )
+        )
     in_fence = False
     fence_indent = ""
     block_start = 0


### PR DESCRIPTION
## Summary

Regression-prevention hardening. Adds blank-line termination enforcement to the CLI explanation table validator, matching the fix applied in azure-monitoring-practical-guide (Oracle-approved 96/100).

- **`scripts/validate_cli_explanations.py`**: adds `find_unterminated_tables()` (fence-aware, so KQL `| where` / `| summarize` lines are not miscounted) which flags any `| Command | Purpose |` table not followed by a blank line or EOF. +4 doctests.
- **`AGENTS.md`**: documents the root cause — Python-Markdown absorbs the line after an unterminated table as a phantom `<td>` row, and neither `mkdocs build --strict` nor Markdown-source review catches it.

## Why

An unterminated explanation table renders a phantom row (`<td>Example output:</td><td></td>`) in the built site. This repo's existing tables are already correctly terminated (validator reports **0 findings**), so this PR changes **no docs** — it only closes the gap that let the defect through in a sibling repo.

## Verification

- Validator: 0 findings on current docs.
- Doctests: 27 pass.